### PR TITLE
Change `com.palantir.gradle-guide` plugin to be a root project plugin

### DIFF
--- a/changelog/@unreleased/pr-90.v2.yml
+++ b/changelog/@unreleased/pr-90.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Change `com.palantir.gradle-guide` plugin to be a root project plugin
+  links:
+  - https://github.com/palantir/gradle-guide/pull/90

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPlugin;
 
 public class GradleGuidePlugin implements Plugin<Project> {
     private static final Set<String> PATCH_CHECKS = Set.of("ConfigurationAvoidanceRegistration", "ProviderGet");
@@ -38,48 +37,79 @@ public class GradleGuidePlugin implements Plugin<Project> {
     }
 
     private static void applyToProject(Project project) {
-        project.getPluginManager().withPlugin("java", _ignored -> {
+        project.getPluginManager().withPlugin("java-library", _ignored -> {
             applyToJavaProject(project);
         });
     }
 
     private static void applyToJavaProject(Project project) {
-        project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
+        project.getConfigurations().getByName("api").getDependencies().whenObjectAdded(dependency -> {
+            if (!dependency.equals(project.getDependencies().gradleApi())) {
+                return;
+            }
 
-        project.getConfigurations().named("errorprone", errorProneConfig -> {
-            String possibleVersion = Optional.ofNullable(
-                            GradleGuidePlugin.class.getPackage().getImplementationVersion())
-                    .map(version -> ":" + version)
-                    .orElse("");
+            project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
 
-            errorProneConfig
-                    .getDependencies()
-                    .addAllLater(project.getConfigurations()
-                            .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-                            .map(compileClasspath -> {
-                                boolean anyCompilationConfigurationHasGradleApiDep = compileClasspath
-                                        .getAllDependencies()
-                                        .contains(project.getDependencies().gradleApi());
+            project.getConfigurations().named("errorprone", errorProneConfig -> {
+                String possibleVersion = Optional.ofNullable(
+                                GradleGuidePlugin.class.getPackage().getImplementationVersion())
+                        .map(version -> ":" + version)
+                        .orElse("");
 
-                                if (anyCompilationConfigurationHasGradleApiDep) {
-                                    return Set.of(project.getDependencies()
-                                            .create("com.palantir.gradle.guide:gradle-guide-error-prone"
-                                                    + possibleVersion));
-                                } else {
-                                    return Set.of();
-                                }
-                            }));
+                errorProneConfig
+                        .getDependencies()
+                        .add(project.getDependencies()
+                                .create("com.palantir.gradle.guide:gradle-guide-error-prone" + possibleVersion));
+            });
+
+            SuppressibleErrorProneExtension suppressibleErrorProneExtension =
+                    project.getExtensions().getByType(SuppressibleErrorProneExtension.class);
+
+            suppressibleErrorProneExtension.getPatchChecks().addAll(PATCH_CHECKS);
+
+            if (project.hasProperty("gradleGuideBestEffortMode")) {
+                suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
+                    errorProneOptions.option("GradleGuide:BestEffortMode", true);
+                });
+            }
         });
 
-        SuppressibleErrorProneExtension suppressibleErrorProneExtension =
-                project.getExtensions().getByType(SuppressibleErrorProneExtension.class);
-
-        suppressibleErrorProneExtension.getPatchChecks().addAll(PATCH_CHECKS);
-
-        if (project.hasProperty("gradleGuideBestEffortMode")) {
-            suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
-                errorProneOptions.option("GradleGuide:BestEffortMode", true);
-            });
-        }
+        //        project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
+        //
+        //        project.getConfigurations().named("errorprone", errorProneConfig -> {
+        //            String possibleVersion = Optional.ofNullable(
+        //                            GradleGuidePlugin.class.getPackage().getImplementationVersion())
+        //                    .map(version -> ":" + version)
+        //                    .orElse("");
+        //
+        //            errorProneConfig
+        //                    .getDependencies()
+        //                    .addAllLater(project.getConfigurations()
+        //                            .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+        //                            .map(compileClasspath -> {
+        //                                boolean anyCompilationConfigurationHasGradleApiDep = compileClasspath
+        //                                        .getAllDependencies()
+        //                                        .contains(project.getDependencies().gradleApi());
+        //
+        //                                if (anyCompilationConfigurationHasGradleApiDep) {
+        //                                    return Set.of(project.getDependencies()
+        //                                            .create("com.palantir.gradle.guide:gradle-guide-error-prone"
+        //                                                    + possibleVersion));
+        //                                } else {
+        //                                    return Set.of();
+        //                                }
+        //                            }));
+        //        });
+        //
+        //        SuppressibleErrorProneExtension suppressibleErrorProneExtension =
+        //                project.getExtensions().getByType(SuppressibleErrorProneExtension.class);
+        //
+        //        suppressibleErrorProneExtension.getPatchChecks().addAll(PATCH_CHECKS);
+        //
+        //        if (project.hasProperty("gradleGuideBestEffortMode")) {
+        //            suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
+        //                errorProneOptions.option("GradleGuide:BestEffortMode", true);
+        //            });
+        //        }
     }
 }

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -44,6 +44,16 @@ public class GradleGuidePlugin implements Plugin<Project> {
     }
 
     private static void applyToJavaProject(Project project) {
+        // We want to only use the gradle-guide error-prones if the project has a gradleApi()
+        // dependency. To use the error-prones, we need to apply the SuppressibleErrorPronePlugin,
+        // but it's actually kinda tricky to conditionally apply this based on the dependency.
+        // The "best" we could do is for each configuration that contributes to compileClasspath,
+        // use whenObjectAdded to detect when the gradleApi() dependency is added, then do everything.
+        // However, this forces us to realise all the dependencies, which is bad and could cause other
+        // dependencies to not be added lazily enough. So instead, we always apply the
+        // suppressible-error-prone plugin (it doesn't really do anything without an error_prone_core or
+        // other errorprone source jar on the classpath), then conditionally lazily add our errorprone
+        // dependency depending on whether the gradleApi() dependency is present.
         project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
 
         project.getConfigurations().named("errorprone", errorProneConfig -> {

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -22,13 +22,23 @@ import java.util.Optional;
 import java.util.Set;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
 
 public class GradleGuidePlugin implements Plugin<Project> {
     private static final Set<String> PATCH_CHECKS = Set.of("ConfigurationAvoidanceRegistration", "ProviderGet");
 
     @Override
-    public final void apply(Project project) {
-        project.getPluginManager().withPlugin("java-gradle-plugin", _ignored -> {
+    public final void apply(Project rootProject) {
+        if (!rootProject.equals(rootProject.getRootProject())) {
+            throw new IllegalStateException(
+                    GradleGuidePlugin.class.getSimpleName() + " must be applied to the root project");
+        }
+
+        rootProject.allprojects(GradleGuidePlugin::applyToProject);
+    }
+
+    private static void applyToProject(Project project) {
+        project.getPluginManager().withPlugin("java", _ignored -> {
             applyToJavaProject(project);
         });
     }
@@ -41,8 +51,23 @@ public class GradleGuidePlugin implements Plugin<Project> {
                 .map(version -> ":" + version)
                 .orElse("");
 
-        project.getDependencies()
-                .add("errorprone", "com.palantir.gradle.guide:gradle-guide-error-prone" + possibleVersion);
+        project.getConfigurations().named("errorprone", errorProneConfig -> {
+            errorProneConfig
+                    .getDependencies()
+                    .addAllLater(project.getConfigurations()
+                            .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+                            .map(compileClasspath -> {
+                                if (compileClasspath
+                                        .getAllDependencies()
+                                        .contains(project.getDependencies().gradleApi())) {
+                                    return Set.of(project.getDependencies()
+                                            .create("com.palantir.gradle.guide:gradle-guide-error-prone"
+                                                    + possibleVersion));
+                                } else {
+                                    return Set.of();
+                                }
+                            }));
+        });
 
         SuppressibleErrorProneExtension suppressibleErrorProneExtension =
                 project.getExtensions().getByType(SuppressibleErrorProneExtension.class);

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPlugin;
 
 public class GradleGuidePlugin implements Plugin<Project> {
     private static final Set<String> PATCH_CHECKS = Set.of("ConfigurationAvoidanceRegistration", "ProviderGet");
@@ -44,42 +43,23 @@ public class GradleGuidePlugin implements Plugin<Project> {
     }
 
     private static void applyToJavaProject(Project project) {
-        // We want to only use the gradle-guide error-prones if the project has a gradleApi()
-        // dependency. To use the error-prones, we need to apply the SuppressibleErrorPronePlugin,
-        // but it's actually kinda tricky to conditionally apply this based on the dependency.
-        // The "best" we could do is for each configuration that contributes to compileClasspath,
-        // use whenObjectAdded to detect when the gradleApi() dependency is added, then do everything.
-        // However, this forces us to realise all the dependencies, which is bad and could cause other
-        // dependencies to not be added lazily enough. So instead, we always apply the
-        // suppressible-error-prone plugin (it doesn't really do anything without an error_prone_core or
-        // other errorprone source jar on the classpath), then conditionally lazily add our errorprone
-        // dependency depending on whether the gradleApi() dependency is present.
+        // We simply apply the gradle-guide errorprones to every project in the repo, even if they do not
+        // have a gradleApi() dependency. It's very hard to conditionally apply the suppressible
+        // errorprone plugin (the best you can do is either put a whenObjectAdded on the dependencies of
+        // each configuration that contributes to compileClasspath, which is bad as it realises all the deps,
+        // or always apply the suppressible error prone plugin and conditionally lazily add our errorprone
+        // dep based on state the compileClasspath, which may not line up correctly timing wise).
+        // So we just apply it unconditionally - it should be fine to have errorprones that work on non-gradle types
+        // running provided we make sure they are not too expensive.
         project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
 
-        project.getConfigurations().named("errorprone", errorProneConfig -> {
-            String possibleVersion = Optional.ofNullable(
-                            GradleGuidePlugin.class.getPackage().getImplementationVersion())
-                    .map(version -> ":" + version)
-                    .orElse("");
+        String possibleVersion = Optional.ofNullable(
+                        GradleGuidePlugin.class.getPackage().getImplementationVersion())
+                .map(version -> ":" + version)
+                .orElse("");
 
-            errorProneConfig
-                    .getDependencies()
-                    .addAllLater(project.getConfigurations()
-                            .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-                            .map(compileClasspath -> {
-                                boolean anyCompilationConfigurationHasGradleApiDep = compileClasspath
-                                        .getAllDependencies()
-                                        .contains(project.getDependencies().gradleApi());
-
-                                if (anyCompilationConfigurationHasGradleApiDep) {
-                                    return Set.of(project.getDependencies()
-                                            .create("com.palantir.gradle.guide:gradle-guide-error-prone"
-                                                    + possibleVersion));
-                                } else {
-                                    return Set.of();
-                                }
-                            }));
-        });
+        project.getDependencies()
+                .add("errorprone", "com.palantir.gradle.guide:gradle-guide-error-prone" + possibleVersion);
 
         SuppressibleErrorProneExtension suppressibleErrorProneExtension =
                 project.getExtensions().getByType(SuppressibleErrorProneExtension.class);

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
 
 public class GradleGuidePlugin implements Plugin<Project> {
     private static final Set<String> PATCH_CHECKS = Set.of("ConfigurationAvoidanceRegistration", "ProviderGet");
@@ -37,79 +38,48 @@ public class GradleGuidePlugin implements Plugin<Project> {
     }
 
     private static void applyToProject(Project project) {
-        project.getPluginManager().withPlugin("java-library", _ignored -> {
+        project.getPluginManager().withPlugin("java", _ignored -> {
             applyToJavaProject(project);
         });
     }
 
     private static void applyToJavaProject(Project project) {
-        project.getConfigurations().getByName("api").getDependencies().whenObjectAdded(dependency -> {
-            if (!dependency.equals(project.getDependencies().gradleApi())) {
-                return;
-            }
+        project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
 
-            project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
+        project.getConfigurations().named("errorprone", errorProneConfig -> {
+            String possibleVersion = Optional.ofNullable(
+                            GradleGuidePlugin.class.getPackage().getImplementationVersion())
+                    .map(version -> ":" + version)
+                    .orElse("");
 
-            project.getConfigurations().named("errorprone", errorProneConfig -> {
-                String possibleVersion = Optional.ofNullable(
-                                GradleGuidePlugin.class.getPackage().getImplementationVersion())
-                        .map(version -> ":" + version)
-                        .orElse("");
+            errorProneConfig
+                    .getDependencies()
+                    .addAllLater(project.getConfigurations()
+                            .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
+                            .map(compileClasspath -> {
+                                boolean anyCompilationConfigurationHasGradleApiDep = compileClasspath
+                                        .getAllDependencies()
+                                        .contains(project.getDependencies().gradleApi());
 
-                errorProneConfig
-                        .getDependencies()
-                        .add(project.getDependencies()
-                                .create("com.palantir.gradle.guide:gradle-guide-error-prone" + possibleVersion));
-            });
-
-            SuppressibleErrorProneExtension suppressibleErrorProneExtension =
-                    project.getExtensions().getByType(SuppressibleErrorProneExtension.class);
-
-            suppressibleErrorProneExtension.getPatchChecks().addAll(PATCH_CHECKS);
-
-            if (project.hasProperty("gradleGuideBestEffortMode")) {
-                suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
-                    errorProneOptions.option("GradleGuide:BestEffortMode", true);
-                });
-            }
+                                if (anyCompilationConfigurationHasGradleApiDep) {
+                                    return Set.of(project.getDependencies()
+                                            .create("com.palantir.gradle.guide:gradle-guide-error-prone"
+                                                    + possibleVersion));
+                                } else {
+                                    return Set.of();
+                                }
+                            }));
         });
 
-        //        project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
-        //
-        //        project.getConfigurations().named("errorprone", errorProneConfig -> {
-        //            String possibleVersion = Optional.ofNullable(
-        //                            GradleGuidePlugin.class.getPackage().getImplementationVersion())
-        //                    .map(version -> ":" + version)
-        //                    .orElse("");
-        //
-        //            errorProneConfig
-        //                    .getDependencies()
-        //                    .addAllLater(project.getConfigurations()
-        //                            .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
-        //                            .map(compileClasspath -> {
-        //                                boolean anyCompilationConfigurationHasGradleApiDep = compileClasspath
-        //                                        .getAllDependencies()
-        //                                        .contains(project.getDependencies().gradleApi());
-        //
-        //                                if (anyCompilationConfigurationHasGradleApiDep) {
-        //                                    return Set.of(project.getDependencies()
-        //                                            .create("com.palantir.gradle.guide:gradle-guide-error-prone"
-        //                                                    + possibleVersion));
-        //                                } else {
-        //                                    return Set.of();
-        //                                }
-        //                            }));
-        //        });
-        //
-        //        SuppressibleErrorProneExtension suppressibleErrorProneExtension =
-        //                project.getExtensions().getByType(SuppressibleErrorProneExtension.class);
-        //
-        //        suppressibleErrorProneExtension.getPatchChecks().addAll(PATCH_CHECKS);
-        //
-        //        if (project.hasProperty("gradleGuideBestEffortMode")) {
-        //            suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
-        //                errorProneOptions.option("GradleGuide:BestEffortMode", true);
-        //            });
-        //        }
+        SuppressibleErrorProneExtension suppressibleErrorProneExtension =
+                project.getExtensions().getByType(SuppressibleErrorProneExtension.class);
+
+        suppressibleErrorProneExtension.getPatchChecks().addAll(PATCH_CHECKS);
+
+        if (project.hasProperty("gradleGuideBestEffortMode")) {
+            suppressibleErrorProneExtension.configureEachErrorProneOptions(errorProneOptions -> {
+                errorProneOptions.option("GradleGuide:BestEffortMode", true);
+            });
+        }
     }
 }

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -46,20 +46,22 @@ public class GradleGuidePlugin implements Plugin<Project> {
     private static void applyToJavaProject(Project project) {
         project.getPluginManager().apply(SuppressibleErrorPronePlugin.class);
 
-        String possibleVersion = Optional.ofNullable(
-                        GradleGuidePlugin.class.getPackage().getImplementationVersion())
-                .map(version -> ":" + version)
-                .orElse("");
-
         project.getConfigurations().named("errorprone", errorProneConfig -> {
+            String possibleVersion = Optional.ofNullable(
+                            GradleGuidePlugin.class.getPackage().getImplementationVersion())
+                    .map(version -> ":" + version)
+                    .orElse("");
+
             errorProneConfig
                     .getDependencies()
                     .addAllLater(project.getConfigurations()
                             .named(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
                             .map(compileClasspath -> {
-                                if (compileClasspath
+                                boolean anyCompilationConfigurationHasGradleApiDep = compileClasspath
                                         .getAllDependencies()
-                                        .contains(project.getDependencies().gradleApi())) {
+                                        .contains(project.getDependencies().gradleApi());
+
+                                if (anyCompilationConfigurationHasGradleApiDep) {
                                     return Set.of(project.getDependencies()
                                             .create("com.palantir.gradle.guide:gradle-guide-error-prone"
                                                     + possibleVersion));

--- a/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
+++ b/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
@@ -19,9 +19,6 @@ package com.palantir.gradle.guide
 import nebula.test.IntegrationSpec
 
 class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
-    File gradleApiSubproject
-    File javaWithoutGradleApiSubproject
-
     def setup() {
         // language=Gradle
         buildFile << '''
@@ -53,8 +50,10 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
                 }
             }
         '''.stripIndent(true)
+    }
 
-        gradleApiSubproject = addSubproject('gradleApi')
+    def 'registers errorprones correctly in subproject that uses gradleApi'() {
+        def gradleApiSubproject = addSubproject('gradleApi')
         def gradleApiSubprojectBuildFile = file('build.gradle', gradleApiSubproject)
 
         // language=Gradle
@@ -64,10 +63,6 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
             }
         '''.stripIndent(true)
 
-        javaWithoutGradleApiSubproject = addSubproject('javaWithoutGradleApi')
-    }
-
-    def 'registers errorprones correctly in subproject that uses gradleApi'() {
         // language=Java
         writeJavaSourceFile('''
             import org.gradle.api.Project;
@@ -86,12 +81,57 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
         stderr.contains 'error: [ConfigurationAvoidanceRegistration]'
     }
 
-    def 'does not enable plugin in java subproject that doesnt use gradleApi'() {
+    def 'registers errorprones correctly in subproject that uses java gradle plugin'() {
+        def javaGradlePluginSubproject = addSubproject('javaGradlePlugin')
+        def javaGradlePluginSubprojectBuildFile = file('build.gradle', javaGradlePluginSubproject)
+
+        // language=Gradle
+        javaGradlePluginSubprojectBuildFile << '''
+            apply plugin: 'java-gradle-plugin'
+        '''.stripIndent(true)
+
+        // language=Java
+        writeJavaSourceFile('''
+            import org.gradle.api.Project;
+
+            final class Bad {
+                public void apply(Project project) {
+                    project.getTasks().create("bad");
+                }
+            }
+        '''.stripIndent(true), javaGradlePluginSubproject)
+
         when:
-        def stderr = runTasksSuccessfully(':javaWithoutGradleApi:compileJava').standardError
+        def stderr = runTasksWithFailure(':javaGradlePlugin:compileJava').standardError
 
         then:
-        !stderr.contains('error: [ConfigurationAvoidanceRegistration]')
+        stderr.contains 'error: [ConfigurationAvoidanceRegistration]'
+    }
+
+    def 'does not enable plugin in java subproject that doesnt use gradleApi'() {
+        def javaWithoutGradleApiSubproject = addSubproject('javaWithoutGradleApi')
+        def javaWithoutGradleApiSubprojectBuildFile = file('build.gradle', javaWithoutGradleApiSubproject)
+
+        // language=Gradle
+        javaWithoutGradleApiSubprojectBuildFile << '''
+            tasks.register('hasGradleGuideErrorProneDep') {
+                inputs.property('hasDep', configurations.named('errorprone').map { 
+                    it.dependencies.stream()
+                        .map { it.toString() }
+                        .anyMatch { it.startsWith('com.palantir.gradle.guide:gradle-guide-error-prone') }
+                })
+                
+                doLast {
+                    println "Has Gradle Guide ErrorProne dep: ${inputs.properties.hasDep}"
+                }
+            }
+        '''.stripIndent(true)
+
+        when:
+        def stderr = runTasksSuccessfully(':javaWithoutGradleApi:hasGradleGuideErrorProneDep').standardOutput
+
+        then:
+        stderr.contains('Has Gradle Guide ErrorProne dep: false')
     }
 
 }

--- a/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
+++ b/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
@@ -107,31 +107,4 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
         then:
         stderr.contains 'error: [ConfigurationAvoidanceRegistration]'
     }
-
-    def 'does not enable plugin in java subproject that doesnt use gradleApi'() {
-        def javaWithoutGradleApiSubproject = addSubproject('javaWithoutGradleApi')
-        def javaWithoutGradleApiSubprojectBuildFile = file('build.gradle', javaWithoutGradleApiSubproject)
-
-        // language=Gradle
-        javaWithoutGradleApiSubprojectBuildFile << '''
-            tasks.register('hasGradleGuideErrorProneDep') {
-                inputs.property('hasDep', configurations.named('errorprone').map { 
-                    it.dependencies.stream()
-                        .map { it.toString() }
-                        .anyMatch { it.startsWith('com.palantir.gradle.guide:gradle-guide-error-prone') }
-                })
-                
-                doLast {
-                    println "Has Gradle Guide ErrorProne dep: ${inputs.properties.hasDep}"
-                }
-            }
-        '''.stripIndent(true)
-
-        when:
-        def stderr = runTasksSuccessfully(':javaWithoutGradleApi:hasGradleGuideErrorProneDep').standardOutput
-
-        then:
-        stderr.contains('Has Gradle Guide ErrorProne dep: false')
-    }
-
 }

--- a/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
+++ b/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
@@ -19,35 +19,55 @@ package com.palantir.gradle.guide
 import nebula.test.IntegrationSpec
 
 class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
+    File gradleApiSubproject
+    File javaWithoutGradleApiSubproject
+
     def setup() {
         // language=Gradle
         buildFile << '''
-            apply plugin: 'java-gradle-plugin'
             apply plugin: 'com.palantir.gradle-guide'
             
-            repositories {
-                mavenCentral()
-                mavenLocal()
-            }
-            
-            dependencies {
-                constraints {
-                    errorprone "com.palantir.gradle.guide:gradle-guide-error-prone:${System.getProperty('gradleGuideErrorProneVersion')}"
+            allprojects {
+                repositories {
+                    mavenCentral()
+                    mavenLocal()
                 }
                 
-                errorprone 'com.google.errorprone:error_prone_core:2.36.0'
-            }
-            
-            suppressibleErrorProne {
-                // Our test source files are placed under `build/nebulatest`, which is ignored by default
-                configureEachErrorProneOptions {
-                    it.excludedPaths.unset()
+                apply plugin: 'java'
+             
+                pluginManager.withPlugin('com.palantir.suppressible-error-prone') {
+                    suppressibleErrorProne {
+                       // Our test source files are placed under `build/nebulatest`, which is ignored by default
+                        configureEachErrorProneOptions {
+                            it.excludedPaths.unset()
+                        }   
+                    }
+                    
+                    dependencies {
+                        constraints {
+                            errorprone "com.palantir.gradle.guide:gradle-guide-error-prone:${System.getProperty('gradleGuideErrorProneVersion')}"
+                        }
+                        
+                        errorprone 'com.google.errorprone:error_prone_core:2.36.0'
+                    }
                 }
             }
         '''.stripIndent(true)
+
+        gradleApiSubproject = addSubproject('gradleApi')
+        def gradleApiSubprojectBuildFile = file('build.gradle', gradleApiSubproject)
+
+        // language=Gradle
+        gradleApiSubprojectBuildFile << '''
+            dependencies {
+                compileOnly gradleApi()
+            }
+        '''.stripIndent(true)
+
+        javaWithoutGradleApiSubproject = addSubproject('javaWithoutGradleApi')
     }
 
-    def 'registers errorprones correctly'() {
+    def 'registers errorprones correctly in subproject that uses gradleApi'() {
         // language=Java
         writeJavaSourceFile('''
             import org.gradle.api.Project;
@@ -57,13 +77,21 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
                     project.getTasks().create("bad");
                 }
             }
-        '''.stripIndent(true))
+        '''.stripIndent(true), gradleApiSubproject)
 
         when:
-        def stderr = runTasksWithFailure('compileJava').standardError
+        def stderr = runTasksWithFailure(':gradleApi:compileJava').standardError
 
         then:
         stderr.contains 'error: [ConfigurationAvoidanceRegistration]'
+    }
+
+    def 'does not enable plugin in java subproject that doesnt use gradleApi'() {
+        when:
+        def stderr = runTasksSuccessfully(':javaWithoutGradleApi:compileJava').standardError
+
+        then:
+        !stderr.contains('error: [ConfigurationAvoidanceRegistration]')
     }
 
 }


### PR DESCRIPTION
## Before this PR
You need to apply the `com.palantir.gradle-guide` plugin to each project that uses the Gradle api. If you add one, you may forget to add the necessary plugin. We'd also need excavator to find all the correct plugins.

## After this PR
==COMMIT_MSG==
Change `com.palantir.gradle-guide` plugin to be a root project plugin
==COMMIT_MSG==

This will make it much easier to excavate out and keep applying the plugins to right places.

## Possible downsides?
~~Perhaps checking for gradleApi() is too complicated - we could just apply it to every java project in the repo...~~ I did the "simple" thing instead and just apply the errorprones to all subprojects.
