### PR TITLE
Best effort errorprone: `dependsOn(taskProvider.get())` -> `dependsOn(taskProvider)`

### DIFF
--- a/changelog/@unreleased/pr-102.v2.yml
+++ b/changelog/@unreleased/pr-102.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: 'Best effort errorprone: `dependsOn(taskProvider.get())` -> `dependsOn(taskProvider)`'
+  links:
+  - https://github.com/palantir/gradle-guide/pull/102

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/besteffort/ProviderImprovements.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/besteffort/ProviderImprovements.java
@@ -50,6 +50,9 @@ public final class ProviderImprovements extends GradleGuideBugChecker
             .onDescendantOfAny("org.gradle.api.Project", "org.gradle.api.provider.ProviderFactory")
             .named("provider");
 
+    private static final Matcher<ExpressionTree> DEPENDS_ON_MATCHER =
+            Matchers.instanceMethod().onDescendantOf("org.gradle.api.Task").named("dependsOn");
+
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (!MATCHER.matches(tree, state) || !bestEffortModeEnabled(state)) {
@@ -63,9 +66,40 @@ public final class ProviderImprovements extends GradleGuideBugChecker
             return description.build();
         }
 
+        // Check if this is a TaskProvider.get() being passed to dependsOn
+        if (handleDependsOnTaskProviderGet(state, fix, tree, memberSelectTree)) {
+            return buildDescription(tree).addFix(fix.build()).build();
+        }
+
+        // Handle the existing case
         replaceNewProviderWithGetCalledInside(state, fix, tree, memberSelectTree);
 
         return buildDescription(tree).addFix(fix.build()).build();
+    }
+
+    private static boolean handleDependsOnTaskProviderGet(
+            VisitorState state, SuggestedFixBuilder fix, MethodInvocationTree tree, MemberSelectTree memberSelectTree) {
+
+        // Check if the parent is a method invocation
+        if (!(state.getPath().getParentPath().getLeaf() instanceof MethodInvocationTree parentMethodInvocation)) {
+            return false;
+        }
+
+        // Check if the parent method is dependsOn
+        if (!DEPENDS_ON_MATCHER.matches(parentMethodInvocation, state)) {
+            return false;
+        }
+
+        // Check if this get() call is an argument to dependsOn
+        for (ExpressionTree arg : parentMethodInvocation.getArguments()) {
+            if (arg.equals(tree)) {
+                // Replace the provider.get() with just provider
+                fix.replace(tree, state.getSourceForNode(memberSelectTree.getExpression()));
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void replaceNewProviderWithGetCalledInside(

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
@@ -283,6 +283,32 @@ class ProviderImprovementsTest {
                 }
                 """);
         }
+
+        @Test
+        void multiple_task_providers_get() {
+            // language=Java
+            refactorFromTo(
+                    """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskProvider;
+
+                class Test {
+                    void test(Task task, TaskProvider<?> provider1, TaskProvider<?> provider2) {
+                        task.dependsOn(provider1.get(), provider2.get());
+                    }
+                }
+                """,
+                    """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskProvider;
+
+                class Test {
+                    void test(Task task, TaskProvider<?> provider1, TaskProvider<?> provider2) {
+                        task.dependsOn(provider1, provider2);
+                    }
+                }
+                """);
+        }
     }
 
     private void refactorFromTo(String input, String output) {

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
@@ -253,6 +253,36 @@ class ProviderImprovementsTest {
                 }
                 """);
         }
+
+        @Test
+        void works_with_custom_task() {
+            // language=Java
+            refactorFromTo(
+                    """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskProvider;
+
+                class Test {
+                    class CustomTask extends org.gradle.api.DefaultTask {}
+
+                    void test(CustomTask customTask, TaskProvider<?> provider) {
+                        customTask.dependsOn(provider.get());
+                    }
+                }
+                """,
+                    """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskProvider;
+
+                class Test {
+                    class CustomTask extends org.gradle.api.DefaultTask {}
+
+                    void test(CustomTask customTask, TaskProvider<?> provider) {
+                        customTask.dependsOn(provider);
+                    }
+                }
+                """);
+        }
     }
 
     private void refactorFromTo(String input, String output) {

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
@@ -226,6 +226,35 @@ class ProviderImprovementsTest {
         }
     }
 
+    @Nested
+    class DependsOnProviderGet {
+        @Test
+        void depends_on_task_provider_get() {
+            // language=Java
+            refactorFromTo(
+                    """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskProvider;
+
+                class Test {
+                    void test(Task task, TaskProvider<?> provider) {
+                        task.dependsOn(provider.get());
+                    }
+                }
+                """,
+                    """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskProvider;
+
+                class Test {
+                    void test(Task task, TaskProvider<?> provider) {
+                        task.dependsOn(provider);
+                    }
+                }
+                """);
+        }
+    }
+
     private void refactorFromTo(String input, String output) {
         bestEffortRefactoringValidator()
                 .addInputLines("Test.java", input)


### PR DESCRIPTION
## Before this PR
After applying other best effort errorprones for providers on old gradle internally, this is a case that can be easily fix.

## After this PR
==COMMIT_MSG==
Best effort errorprone: `dependsOn(taskProvider.get())` -> `dependsOn(taskProvider)`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

