### PR TITLE
Allow interfaces for Tasks and Extensions

### DIFF
--- a/changelog/@unreleased/pr-108.v2.yml
+++ b/changelog/@unreleased/pr-108.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow interfaces for Tasks and Extensions
+  links:
+  - https://github.com/palantir/gradle-guide/pull/108

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -30,10 +30,10 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Type;
 import java.util.Optional;
-import java.util.function.Predicate;
 import javax.lang.model.element.Modifier;
 
 @AutoService(BugChecker.class)
@@ -48,14 +48,17 @@ import javax.lang.model.element.Modifier;
 public final class NonAbstractGradleType extends GradleGuideBugChecker
         implements BugChecker.ClassTreeMatcher, BugChecker.MethodInvocationTreeMatcher {
     private static final Matcher<ClassTree> IS_TASK = Matchers.isSubtypeOf("org.gradle.api.Task");
-    private static final Matcher<ExpressionTree> IS_EXTENSION_CREATE =
-            Matchers.methodInvocation(Matchers.instanceMethod()
-                    .onDescendantOf("org.gradle.api.plugins.ExtensionContainer")
-                    .named("create"));
+    private static final Matcher<ExpressionTree> IS_EXTENSION_CREATE = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.plugins.ExtensionContainer")
+            .named("create");
     private static final Supplier<Type> CLASS_TYPE_SUPPLIER = Suppliers.typeFromString("java.lang.Class");
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
+        if (tree.getKind().equals(Kind.INTERFACE)) {
+            return Description.NO_MATCH;
+        }
+
         if (tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
             return Description.NO_MATCH;
         }
@@ -86,7 +89,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         ExpressionTree classArg = tree.getArguments().get(1);
 
         return typeArgumentFromPossibleClassType(state, classArg)
-                .filter(Predicate.not(NonAbstractGradleType::isTypeAbstract))
+                .filter(type -> !isTypeAbstract(type) && !isTypeInterface(type))
                 .map(nonAbstractType -> buildDescription(tree).build())
                 .orElse(Description.NO_MATCH);
     }
@@ -102,6 +105,10 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
 
     private static boolean isTypeAbstract(Type type) {
         return (type.tsym.flags() & Flags.ABSTRACT) != 0;
+    }
+
+    private static boolean isTypeInterface(Type type) {
+        return (type.tsym.flags() & Flags.INTERFACE) != 0;
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -89,7 +89,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         ExpressionTree classArg = tree.getArguments().get(1);
 
         return typeArgumentFromPossibleClassType(state, classArg)
-                .filter(type -> !isTypeAbstract(type) && !isTypeInterface(type))
+                .filter(type -> !(isTypeAbstract(type) || type.isInterface()))
                 .map(nonAbstractType -> buildDescription(tree).build())
                 .orElse(Description.NO_MATCH);
     }
@@ -105,10 +105,6 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
 
     private static boolean isTypeAbstract(Type type) {
         return (type.tsym.flags() & Flags.ABSTRACT) != 0;
-    }
-
-    private static boolean isTypeInterface(Type type) {
-        return (type.tsym.flags() & Flags.INTERFACE) != 0;
     }
 
     @Override

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -47,10 +47,40 @@ class NonAbstractGradleTypeTest {
                     abstract class Test extends DefaultTask {}
                     """);
         }
+
+        @Test
+        void interface_task_should_be_fine() {
+            test(
+                    """
+                    import org.gradle.api.Task;
+
+                    interface TestTask extends Task {}
+                    """);
+        }
     }
 
     @Nested
     class Extensions {
+
+        // language=Java
+        private String pluginCode =
+                """
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+
+            public class FooPlugin implements Plugin<Project> {
+                @Override
+                public void apply(Project project) {
+                    // BUG: Diagnostic contains: abstract class
+                    project.getExtensions().create("foo", FooExtension.class);
+
+                    Class<?> fooExtensionClass = FooExtension.class;
+                    // BUG: Diagnostic contains: abstract class
+                    project.getExtensions().create("foo", fooExtensionClass);
+                }
+            }
+            """;
+
         @Test
         void non_abstract_extension_should_fail() {
             compilationTestHelper
@@ -58,33 +88,30 @@ class NonAbstractGradleTypeTest {
                             "FooExtension.java",
                             // language=Java
                             "class FooExtension {}")
-                    .addSourceLines(
-                            "FooPlugin.java",
-                            // language=Java
-                            """
-                    import org.gradle.api.Plugin;
-                    import org.gradle.api.Project;
-
-                    public class FooPlugin implements Plugin<Project> {
-                        @Override
-                        public void apply(Project project) {
-                            // BUG: Diagnostic contains: abstract class
-                            project.getExtensions().create("foo", FooExtension.class);
-
-                            Class<?> fooExtensionClass = FooExtension.class;
-                            // BUG: Diagnostic contains: abstract class
-                            project.getExtensions().create("foo", fooExtensionClass);
-                        }
-                    }
-                    """)
+                    .addSourceLines("FooPlugin.java", pluginCode)
                     .doTest();
         }
 
         @Test
         void abstract_extension_is_fine() {
-            test("""
-                abstract class FooExtension {}
-                """);
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            // language=Java
+                            "abstract class FooExtension {}")
+                    .addSourceLines("FooPlugin.java", pluginCode)
+                    .doTest();
+        }
+
+        @Test
+        void interface_extension_is_fine() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            // language=Java
+                            "interface FooExtension {}")
+                    .addSourceLines("FooPlugin.java", pluginCode)
+                    .doTest();
         }
     }
 

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -74,7 +74,7 @@ class NonAbstractGradleTypeTest {
                     // BUG: Diagnostic contains: abstract class
                     project.getExtensions().create("foo", FooExtension.class);
 
-                    Class<?> fooExtensionClass = FooExtension.class;
+                    Class<FooExtension> fooExtensionClass = FooExtension.class;
                     // BUG: Diagnostic contains: abstract class
                     project.getExtensions().create("foo", fooExtensionClass);
                 }
@@ -100,6 +100,7 @@ class NonAbstractGradleTypeTest {
                             // language=Java
                             "abstract class FooExtension {}")
                     .addSourceLines("FooPlugin.java", pluginCode)
+                    .expectNoDiagnostics()
                     .doTest();
         }
 
@@ -111,6 +112,7 @@ class NonAbstractGradleTypeTest {
                             // language=Java
                             "interface FooExtension {}")
                     .addSourceLines("FooPlugin.java", pluginCode)
+                    .expectNoDiagnostics()
                     .doTest();
         }
     }


### PR DESCRIPTION
## Before this PR
In #101 we banned all non-abstract tasks and extensions. However, this also banned interfaces. I think interfaces are possibly non-ideal (may need to convert later to abstract class to get private methods, this can be an ABI break), but lets not block them for now.

## After this PR
==COMMIT_MSG==
Allow interfaces for Tasks and Extensions
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

