### PR TITLE
Expanded NonAbstractGradleType to add ability to detect if gradle managed properties are abstract and start with get

### DIFF
--- a/changelog/@unreleased/pr-119.v2.yml
+++ b/changelog/@unreleased/pr-119.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Finlayw/check get and abstract
+  links:
+  - https://github.com/palantir/gradle-guide/pull/119

--- a/changelog/@unreleased/pr-119.v2.yml
+++ b/changelog/@unreleased/pr-119.v2.yml
@@ -1,5 +1,6 @@
 type: improvement
 improvement:
-  description: Finlayw/check get and abstract
+  description: Expanded NonAbstractGradleType to add ability to detect if gradle managed
+    properties are abstract and start with get
   links:
   - https://github.com/palantir/gradle-guide/pull/119

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -91,9 +91,11 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         if (enclosingClass == null) {
             return Description.NO_MATCH;
         }
+
         if (!IS_TASK.matches(enclosingClass, state)) {
             return Description.NO_MATCH;
         }
+
         if (!isManagedPropertyGetter(method, state)) {
             return Description.NO_MATCH;
         }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -63,6 +63,10 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
     private static final Supplier<Type> CLASS_TYPE_SUPPLIER = Suppliers.typeFromString("java.lang.Class");
     private static final Supplier<Type> PROVIDER_TYPE_SUPPLIER =
             Suppliers.typeFromString("org.gradle.api.provider.Provider");
+    private static final Supplier<Type> DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER =
+            Suppliers.typeFromString("org.gradle.api.DomainObjectCollection");
+    private static final Supplier<Type> FILE_COLLECTION_TYPE_SUPPLIER =
+            Suppliers.typeFromString("org.gradle.api.file.FileCollection");
 
     private static final String ABSTRACT_PROPERTY_METHOD_MSG = "Properties on Tasks or Extensions should be declared "
             + "abstract. Declare this method as 'public abstract', e.g., 'public abstract Property<Integer> "
@@ -138,7 +142,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         }
 
         Type varType = ASTHelpers.getType(tree);
-        if (varType != null && isSubtypeOfProvider(varType, state)) {
+        if (varType != null && isManagedPropertyType(varType, state)) {
             return buildDescription(tree).setMessage(PROPERTY_FIELD_MSG).build();
         }
 
@@ -185,7 +189,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         return StreamSupport.stream(extSym.members().getSymbols().spliterator(), false)
                 .filter(memberSym -> memberSym instanceof VarSymbol)
                 .map(memberSym -> (VarSymbol) memberSym)
-                .anyMatch(varSym -> isSubtypeOfProvider(varSym.type, state));
+                .anyMatch(varSym -> isManagedPropertyType(varSym.type, state));
     }
 
     private Description checkManagedPropertyGetters(ClassSymbol extSym, MethodInvocationTree tree, VisitorState state) {
@@ -223,12 +227,30 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         return symbol != null && symbol.getModifiers().contains(Modifier.ABSTRACT);
     }
 
+    private static boolean isManagedPropertyType(Type type, VisitorState state) {
+        return isSubtypeOfProvider(type, state)
+                || isSubtypeOfDomainObjectCollection(type, state)
+                || isSubtypeOfFileCollection(type, state);
+    }
+
+    private static boolean isSubtypeOfProvider(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, PROVIDER_TYPE_SUPPLIER.get(state), state);
+    }
+
+    private static boolean isSubtypeOfDomainObjectCollection(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER.get(state), state);
+    }
+
+    private static boolean isSubtypeOfFileCollection(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, FILE_COLLECTION_TYPE_SUPPLIER.get(state), state);
+    }
+
     private static boolean isManagedPropertyGetter(MethodTree method, VisitorState state) {
         if (!method.getParameters().isEmpty()) {
             return false;
         }
         Type returnType = ASTHelpers.getType(method.getReturnType());
-        return returnType != null && isSubtypeOfProvider(returnType, state);
+        return returnType != null && isManagedPropertyType(returnType, state);
     }
 
     private static boolean isManagedPropertyGetter(MethodSymbol method, VisitorState state) {
@@ -236,11 +258,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             return false;
         }
         Type returnType = method.getReturnType();
-        return returnType != null && isSubtypeOfProvider(returnType, state);
-    }
-
-    private static boolean isSubtypeOfProvider(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, PROVIDER_TYPE_SUPPLIER.get(state), state);
+        return returnType != null && isManagedPropertyType(returnType, state);
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -65,7 +65,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             + "syntax work of the box.";
 
     private static final String PROPERTY_GETTER_NAMING_MSG =
-            "Gradle managed property getter methods must be named starting with 'get', e.g., 'getFoo'. This naming "
+            "Properties on Tasks or Extensions should be named starting with 'get', e.g., 'getFoo'. This naming "
                     + "convention is required for Gradle to recognize and manage the property, enabling automatic "
                     + "property wiring and Groovy DSL support, this will automatically this will make the `foo = 3` "
                     + "groovy syntax work of the box.";

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -1,3 +1,18 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.gradle.guide.errorprone;
 
 import com.google.auto.service.AutoService;
@@ -136,9 +151,8 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                     }
                     if (!memberSym.getSimpleName().toString().startsWith("get")) {
                         return buildDescription(tree)
-                                .setMessage(
-                                        "Gradle managed property getter in Extension must be named starting with 'get': "
-                                                + memberSym.getSimpleName())
+                                .setMessage("Gradle managed property getter in Extension must start with 'get': "
+                                        + memberSym.getSimpleName())
                                 .build();
                     }
                     return null;

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -1,18 +1,3 @@
-/*
- * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.palantir.gradle.guide.errorprone;
 
 import com.google.auto.service.AutoService;
@@ -39,7 +24,6 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.StreamSupport;
 import javax.lang.model.element.Modifier;
 
@@ -62,6 +46,8 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             .onDescendantOf("org.gradle.api.plugins.ExtensionContainer")
             .named("create");
     private static final Supplier<Type> CLASS_TYPE_SUPPLIER = Suppliers.typeFromString("java.lang.Class");
+    private static final Supplier<Type> PROVIDER_TYPE_SUPPLIER =
+            Suppliers.typeFromString("org.gradle.api.provider.Provider");
 
     private static final String ABSTRACT_PROPERTY_METHOD_MSG = "Properties on Tasks or Extensions should be declared "
             + "abstract. Declare this method as 'public abstract', e.g., 'public abstract Property<Integer> "
@@ -79,15 +65,6 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             + "Instead, declare an abstract getter method, e.g., 'public abstract Property<String> getFoo();'. This "
             + "enables Gradle to inject the property implementation automatically, removes boilerplate, and supports "
             + "the Groovy DSL (e.g. `foo = 3`).";
-
-    private static final Set<String> SUPPORTED_PROPERTY_TYPES = Set.of(
-            "org.gradle.api.provider.Property",
-            "org.gradle.api.provider.ListProperty",
-            "org.gradle.api.provider.SetProperty",
-            "org.gradle.api.provider.MapProperty",
-            "org.gradle.api.file.RegularFileProperty",
-            "org.gradle.api.file.DirectoryProperty",
-            "org.gradle.api.provider.Provider");
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
@@ -146,9 +123,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         }
 
         Type varType = ASTHelpers.getType(tree);
-        if (varType != null
-                && SUPPORTED_PROPERTY_TYPES.contains(
-                        varType.tsym.getQualifiedName().toString())) {
+        if (varType != null && isSubtypeOfProvider(varType, state)) {
             return buildDescription(tree).setMessage(PROPERTY_FIELD_MSG).build();
         }
 
@@ -184,24 +159,18 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         }
 
         ClassSymbol extSym = (ClassSymbol) extensionType.tsym;
-        if (hasPropertyField(extSym)) {
+        if (hasPropertyField(extSym, state)) {
             return buildDescription(tree).setMessage(PROPERTY_FIELD_MSG).build();
         }
 
         return checkManagedPropertyGetters(extSym, tree, state);
     }
 
-    private static boolean hasPropertyField(ClassSymbol extSym) {
+    private static boolean hasPropertyField(ClassSymbol extSym, VisitorState state) {
         return StreamSupport.stream(extSym.members().getSymbols().spliterator(), false)
                 .filter(memberSym -> memberSym instanceof VarSymbol)
                 .map(memberSym -> (VarSymbol) memberSym)
-                .anyMatch(varSym -> {
-                    Type fieldType = varSym.type;
-                    return fieldType != null
-                            && fieldType.tsym != null
-                            && SUPPORTED_PROPERTY_TYPES.contains(
-                                    fieldType.tsym.getQualifiedName().toString());
-                });
+                .anyMatch(varSym -> isSubtypeOfProvider(varSym.type, state));
     }
 
     private Description checkManagedPropertyGetters(ClassSymbol extSym, MethodInvocationTree tree, VisitorState state) {
@@ -228,7 +197,6 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
     }
 
     private static Optional<Type> typeArgumentFromPossibleClassType(VisitorState state, ExpressionTree classArg) {
-        // From a possible Class<T> extract T
         return Optional.ofNullable(ASTHelpers.getType(classArg))
                 .filter(argType -> ASTHelpers.isSubtype(argType, CLASS_TYPE_SUPPLIER.get(state), state))
                 .filter(argType -> !argType.getTypeArguments().isEmpty())
@@ -245,11 +213,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             return false;
         }
         Type returnType = ASTHelpers.getType(method.getReturnType());
-        if (returnType == null || returnType.tsym == null) {
-            return false;
-        }
-        String rawType = returnType.tsym.getQualifiedName().toString();
-        return SUPPORTED_PROPERTY_TYPES.contains(rawType);
+        return returnType != null && isSubtypeOfProvider(returnType, state);
     }
 
     private static boolean isManagedPropertyGetter(MethodSymbol method, VisitorState state) {
@@ -257,11 +221,11 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             return false;
         }
         Type returnType = method.getReturnType();
-        if (returnType == null || returnType.tsym == null) {
-            return false;
-        }
-        String rawType = returnType.tsym.getQualifiedName().toString();
-        return SUPPORTED_PROPERTY_TYPES.contains(rawType);
+        return returnType != null && isSubtypeOfProvider(returnType, state);
+    }
+
+    private static boolean isSubtypeOfProvider(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, PROVIDER_TYPE_SUPPLIER.get(state), state);
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -31,7 +31,7 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree.Kind;
-import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
@@ -73,7 +73,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             return Description.NO_MATCH;
         }
 
-        if (tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
+        if (isAbstract(ASTHelpers.getSymbol(tree))) {
             return Description.NO_MATCH;
         }
 
@@ -99,7 +99,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             return Description.NO_MATCH;
         }
 
-        if (!method.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
+        if (!isAbstract(ASTHelpers.getSymbol(method))) {
             return buildDescription(method)
                     .setMessage("Gradle managed property getter methods must be abstract. "
                             + "Declare this method as 'public abstract', e.g., "
@@ -144,7 +144,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         Type extensionType = extensionTypeOpt.get();
 
         // Check: must be abstract, not interface
-        if (!(isTypeAbstract(extensionType) || extensionType.isInterface())) {
+        if (!(isAbstract(extensionType.tsym) || extensionType.isInterface())) {
             return buildDescription(tree).build();
         }
 
@@ -155,7 +155,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                 .map(memberSym -> (MethodSymbol) memberSym)
                 .filter(memberSym -> isManagedPropertyGetter(memberSym, state))
                 .map(memberSym -> {
-                    if ((memberSym.flags() & Flags.ABSTRACT) == 0) {
+                    if (!isAbstract(memberSym)) {
                         return buildDescription(tree)
                                 .setMessage("Gradle managed property getter methods must be abstract. "
                                         + "Declare this method as 'public abstract', e.g., "
@@ -188,8 +188,8 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                 .filter(extensionType -> extensionType.tsym != null);
     }
 
-    private static boolean isTypeAbstract(Type type) {
-        return (type.tsym.flags() & Flags.ABSTRACT) != 0;
+    private static boolean isAbstract(Symbol symbol) {
+        return symbol != null && symbol.getModifiers().contains(Modifier.ABSTRACT);
     }
 
     private static boolean isManagedPropertyGetter(MethodTree method, VisitorState state) {

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -76,9 +76,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
 
         if (IS_TASK.matches(tree, state)) {
             if (!tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
-                return buildDescription(tree)
-                        .setMessage("Gradle managed Task types must be abstract classes.")
-                        .build();
+                return buildDescription(tree).build();
             }
             return tree.getMembers().stream()
                     .filter(member -> member instanceof MethodTree)

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -58,6 +58,18 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             .named("create");
     private static final Supplier<Type> CLASS_TYPE_SUPPLIER = Suppliers.typeFromString("java.lang.Class");
 
+    private static final String ABSTRACT_PROPERTY_METHOD_MSG = "Properties on Tasks or Extensions should be declared "
+            + "abstract. Declare this method as 'public abstract', e.g., 'public abstract Property<Integer> "
+            + "getFoo();'. This enables Gradle to inject the property implementation automatically, removing "
+            + "boilerplate and supporting the Groovy DSL , this will automatically this will make the `foo = 3` groovy "
+            + "syntax work of the box.";
+
+    private static final String PROPERTY_GETTER_NAMING_MSG =
+            "Gradle managed property getter methods must be named starting with 'get', e.g., 'getFoo'. This naming "
+                    + "convention is required for Gradle to recognize and manage the property, enabling automatic "
+                    + "property wiring and Groovy DSL support, this will automatically this will make the `foo = 3` "
+                    + "groovy syntax work of the box.";
+
     private static final Set<String> SUPPORTED_PROPERTY_TYPES = Set.of(
             "org.gradle.api.provider.Property",
             "org.gradle.api.provider.ListProperty",
@@ -101,19 +113,12 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
 
         if (!isAbstract(ASTHelpers.getSymbol(method))) {
             return buildDescription(method)
-                    .setMessage("Gradle managed property getter methods must be abstract. "
-                            + "Declare this method as 'public abstract', e.g., "
-                            + "'public abstract Property<Integer> getFoo();'. "
-                            + "This enables Gradle to inject the property implementation "
-                            + "automatically, removing boilerplate and supporting the Groovy DSL.")
+                    .setMessage(ABSTRACT_PROPERTY_METHOD_MSG)
                     .build();
         }
         if (!method.getName().toString().startsWith("get")) {
             return buildDescription(method)
-                    .setMessage("Gradle managed property getter methods must be named starting with 'get', "
-                            + "e.g., 'getFoo'. This naming convention is required for Gradle "
-                            + "to recognize and manage the property, enabling automatic "
-                            + "property wiring and Groovy DSL support.")
+                    .setMessage(PROPERTY_GETTER_NAMING_MSG)
                     .build();
         }
         return Description.NO_MATCH;
@@ -157,19 +162,12 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                 .map(memberSym -> {
                     if (!isAbstract(memberSym)) {
                         return buildDescription(tree)
-                                .setMessage("Gradle managed property getter methods must be abstract. "
-                                        + "Declare this method as 'public abstract', e.g., "
-                                        + "'public abstract Property<Integer> getFoo();'. "
-                                        + "This enables Gradle to inject the property implementation automatically, "
-                                        + "removing boilerplate and supporting the Groovy DSL.")
+                                .setMessage(ABSTRACT_PROPERTY_METHOD_MSG)
                                 .build();
                     }
                     if (!memberSym.getSimpleName().toString().startsWith("get")) {
                         return buildDescription(tree)
-                                .setMessage("Gradle managed property getter methods must be named starting with 'get', "
-                                        + "e.g., 'getFoo'. This naming convention is required for Gradle to recognize "
-                                        + "and manage the property, enabling automatic property wiring and Groovy DSL "
-                                        + "support.")
+                                .setMessage(PROPERTY_GETTER_NAMING_MSG)
                                 .build();
                     }
                     return null;

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -1,19 +1,3 @@
-/*
- * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.palantir.gradle.guide.errorprone;
 
 import com.google.auto.service.AutoService;
@@ -30,10 +14,16 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.code.Flags;
+import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.StreamSupport;
 import javax.lang.model.element.Modifier;
 
 @AutoService(BugChecker.class)
@@ -53,18 +43,48 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             .named("create");
     private static final Supplier<Type> CLASS_TYPE_SUPPLIER = Suppliers.typeFromString("java.lang.Class");
 
+    private static final Set<String> SUPPORTED_PROPERTY_TYPES = Set.of(
+            "org.gradle.api.provider.Property",
+            "org.gradle.api.provider.ListProperty",
+            "org.gradle.api.provider.SetProperty",
+            "org.gradle.api.provider.MapProperty",
+            "org.gradle.api.file.RegularFileProperty",
+            "org.gradle.api.file.DirectoryProperty",
+            "org.gradle.api.provider.Provider",
+            "org.gradle.api.model.ObjectFactory");
+
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {
         if (tree.getKind().equals(Kind.INTERFACE)) {
             return Description.NO_MATCH;
         }
 
-        if (tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
-            return Description.NO_MATCH;
-        }
-
         if (IS_TASK.matches(tree, state)) {
-            return buildDescription(tree).build();
+            if (!tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
+                return buildDescription(tree)
+                        .setMessage("Gradle managed Task types must be abstract classes.")
+                        .build();
+            }
+            return tree.getMembers().stream()
+                    .filter(member -> member instanceof MethodTree)
+                    .map(member -> (MethodTree) member)
+                    .filter(method -> isManagedPropertyGetter(method, state))
+                    .map(method -> {
+                        if (!method.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
+                            return buildDescription(method)
+                                    .setMessage("Gradle managed property getter must be abstract.")
+                                    .build();
+                        }
+                        if (!method.getName().toString().startsWith("get")) {
+                            return buildDescription(method)
+                                    .setMessage("Gradle managed property getter must be named starting with 'get'.")
+                                    .build();
+                        }
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(Description.NO_MATCH);
         }
 
         return Description.NO_MATCH;
@@ -88,9 +108,43 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         // Get the second argument which should be the class type
         ExpressionTree classArg = tree.getArguments().get(1);
 
-        return typeArgumentFromPossibleClassType(state, classArg)
-                .filter(type -> !(isTypeAbstract(type) || type.isInterface()))
-                .map(nonAbstractType -> buildDescription(tree).build())
+        Optional<Type> extensionTypeOpt = typeArgumentFromPossibleClassType(state, classArg);
+        if (extensionTypeOpt.isEmpty()) {
+            return Description.NO_MATCH;
+        }
+        Type extensionType = extensionTypeOpt.get();
+
+        // Check: must be abstract, not interface
+        if (!(isTypeAbstract(extensionType) || extensionType.isInterface())) {
+            return buildDescription(tree)
+                    .setMessage("Gradle managed Extension types must be abstract classes.")
+                    .build();
+        }
+
+        ClassSymbol extSym = (ClassSymbol) extensionType.tsym;
+        // Stream over the symbol table for methods
+        return StreamSupport.stream(extSym.members().getSymbols().spliterator(), false)
+                .filter(memberSym -> memberSym instanceof MethodSymbol)
+                .map(memberSym -> (MethodSymbol) memberSym)
+                .filter(memberSym -> isManagedPropertyGetter(memberSym, state))
+                .map(memberSym -> {
+                    if ((memberSym.flags() & Flags.ABSTRACT) == 0) {
+                        return buildDescription(tree)
+                                .setMessage("Gradle managed property getter in Extension must be abstract: "
+                                        + memberSym.getSimpleName())
+                                .build();
+                    }
+                    if (!memberSym.getSimpleName().toString().startsWith("get")) {
+                        return buildDescription(tree)
+                                .setMessage(
+                                        "Gradle managed property getter in Extension must be named starting with 'get': "
+                                                + memberSym.getSimpleName())
+                                .build();
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .findFirst()
                 .orElse(Description.NO_MATCH);
     }
 
@@ -105,6 +159,30 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
 
     private static boolean isTypeAbstract(Type type) {
         return (type.tsym.flags() & Flags.ABSTRACT) != 0;
+    }
+
+    private static boolean isManagedPropertyGetter(MethodTree method, VisitorState state) {
+        if (!method.getParameters().isEmpty()) {
+            return false;
+        }
+        Type returnType = ASTHelpers.getType(method.getReturnType());
+        if (returnType == null || returnType.tsym == null) {
+            return false;
+        }
+        String rawType = returnType.tsym.getQualifiedName().toString();
+        return SUPPORTED_PROPERTY_TYPES.contains(rawType);
+    }
+
+    private static boolean isManagedPropertyGetter(MethodSymbol method, VisitorState state) {
+        if (!method.getParameters().isEmpty()) {
+            return false;
+        }
+        Type returnType = method.getReturnType();
+        if (returnType == null || returnType.tsym == null) {
+            return false;
+        }
+        String rawType = returnType.tsym.getQualifiedName().toString();
+        return SUPPORTED_PROPERTY_TYPES.contains(rawType);
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -65,8 +65,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             "org.gradle.api.provider.MapProperty",
             "org.gradle.api.file.RegularFileProperty",
             "org.gradle.api.file.DirectoryProperty",
-            "org.gradle.api.provider.Provider",
-            "org.gradle.api.model.ObjectFactory");
+            "org.gradle.api.provider.Provider");
 
     @Override
     public Description matchClass(ClassTree tree, VisitorState state) {

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -77,7 +77,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         }
 
         if (IS_TASK.matches(tree, state)) {
-            return buildDescription(tree).build();
+            return describeMatch(tree);
         }
 
         return Description.NO_MATCH;
@@ -155,7 +155,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         Type extensionType = extensionTypeOpt.get();
 
         if (!(isAbstract(extensionType.tsym) || extensionType.isInterface())) {
-            return buildDescription(tree).build();
+            return describeMatch(tree);
         }
 
         ClassSymbol extSym = (ClassSymbol) extensionType.tsym;

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -51,7 +51,7 @@ import javax.lang.model.element.Modifier;
                 + "as you declare eg `public abstract Property<Integer> getFoo()`, this will automatically "
                 + "make the `foo = 3` groovy syntax work of the box.")
 public final class NonAbstractGradleType extends GradleGuideBugChecker
-        implements BugChecker.ClassTreeMatcher, BugChecker.MethodInvocationTreeMatcher {
+        implements BugChecker.ClassTreeMatcher, BugChecker.MethodInvocationTreeMatcher, BugChecker.MethodTreeMatcher {
     private static final Matcher<ClassTree> IS_TASK = Matchers.isSubtypeOf("org.gradle.api.Task");
     private static final Matcher<ExpressionTree> IS_EXTENSION_CREATE = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.plugins.ExtensionContainer")
@@ -74,40 +74,47 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
             return Description.NO_MATCH;
         }
 
-        if (IS_TASK.matches(tree, state)) {
-            if (!tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
-                return buildDescription(tree).build();
-            }
-            return tree.getMembers().stream()
-                    .filter(member -> member instanceof MethodTree)
-                    .map(member -> (MethodTree) member)
-                    .filter(method -> isManagedPropertyGetter(method, state))
-                    .map(method -> {
-                        if (!method.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
-                            return buildDescription(method)
-                                    .setMessage("Gradle managed property getter methods must be abstract. "
-                                            + "Declare this method as 'public abstract', e.g., "
-                                            + "'public abstract Property<Integer> getFoo();'. "
-                                            + "This enables Gradle to inject the property implementation "
-                                            + "automatically, removing boilerplate and supporting the Groovy DSL.")
-                                    .build();
-                        }
-                        if (!method.getName().toString().startsWith("get")) {
-                            return buildDescription(method)
-                                    .setMessage(
-                                            "Gradle managed property getter methods must be named starting with 'get', "
-                                                    + "e.g., 'getFoo'. This naming convention is required for Gradle "
-                                                    + "to recognize and manage the property, enabling automatic "
-                                                    + "property wiring and Groovy DSL support.")
-                                    .build();
-                        }
-                        return null;
-                    })
-                    .filter(Objects::nonNull)
-                    .findFirst()
-                    .orElse(Description.NO_MATCH);
+        if (tree.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
+            return Description.NO_MATCH;
         }
 
+        if (IS_TASK.matches(tree, state)) {
+            return buildDescription(tree).build();
+        }
+
+        return Description.NO_MATCH;
+    }
+
+    @Override
+    public Description matchMethod(MethodTree method, VisitorState state) {
+        ClassTree enclosingClass = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
+        if (enclosingClass == null) {
+            return Description.NO_MATCH;
+        }
+        if (!IS_TASK.matches(enclosingClass, state)) {
+            return Description.NO_MATCH;
+        }
+        if (!isManagedPropertyGetter(method, state)) {
+            return Description.NO_MATCH;
+        }
+
+        if (!method.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
+            return buildDescription(method)
+                    .setMessage("Gradle managed property getter methods must be abstract. "
+                            + "Declare this method as 'public abstract', e.g., "
+                            + "'public abstract Property<Integer> getFoo();'. "
+                            + "This enables Gradle to inject the property implementation "
+                            + "automatically, removing boilerplate and supporting the Groovy DSL.")
+                    .build();
+        }
+        if (!method.getName().toString().startsWith("get")) {
+            return buildDescription(method)
+                    .setMessage("Gradle managed property getter methods must be named starting with 'get', "
+                            + "e.g., 'getFoo'. This naming convention is required for Gradle "
+                            + "to recognize and manage the property, enabling automatic "
+                            + "property wiring and Groovy DSL support.")
+                    .build();
+        }
         return Description.NO_MATCH;
     }
 

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -1,3 +1,18 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.palantir.gradle.guide.errorprone;
 
 import com.google.auto.service.AutoService;

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -85,12 +85,20 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                     .map(method -> {
                         if (!method.getModifiers().getFlags().contains(Modifier.ABSTRACT)) {
                             return buildDescription(method)
-                                    .setMessage("Gradle managed property getter must be abstract.")
+                                    .setMessage("Gradle managed property getter methods must be abstract. "
+                                            + "Declare this method as 'public abstract', e.g., "
+                                            + "'public abstract Property<Integer> getFoo();'. "
+                                            + "This enables Gradle to inject the property implementation "
+                                            + "automatically, removing boilerplate and supporting the Groovy DSL.")
                                     .build();
                         }
                         if (!method.getName().toString().startsWith("get")) {
                             return buildDescription(method)
-                                    .setMessage("Gradle managed property getter must be named starting with 'get'.")
+                                    .setMessage(
+                                            "Gradle managed property getter methods must be named starting with 'get', "
+                                                    + "e.g., 'getFoo'. This naming convention is required for Gradle "
+                                                    + "to recognize and manage the property, enabling automatic "
+                                                    + "property wiring and Groovy DSL support.")
                                     .build();
                         }
                         return null;
@@ -143,14 +151,19 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                 .map(memberSym -> {
                     if ((memberSym.flags() & Flags.ABSTRACT) == 0) {
                         return buildDescription(tree)
-                                .setMessage("Gradle managed property getter in Extension must be abstract: "
-                                        + memberSym.getSimpleName())
+                                .setMessage("Gradle managed property getter methods must be abstract. "
+                                        + "Declare this method as 'public abstract', e.g., "
+                                        + "'public abstract Property<Integer> getFoo();'. "
+                                        + "This enables Gradle to inject the property implementation automatically, "
+                                        + "removing boilerplate and supporting the Groovy DSL.")
                                 .build();
                     }
                     if (!memberSym.getSimpleName().toString().startsWith("get")) {
                         return buildDescription(tree)
-                                .setMessage("Gradle managed property getter in Extension must start with 'get': "
-                                        + memberSym.getSimpleName())
+                                .setMessage("Gradle managed property getter methods must be named starting with 'get', "
+                                        + "e.g., 'getFoo'. This naming convention is required for Gradle to recognize "
+                                        + "and manage the property, enabling automatic property wiring and Groovy DSL "
+                                        + "support.")
                                 .build();
                     }
                     return null;

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -31,9 +31,11 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,7 +53,10 @@ import javax.lang.model.element.Modifier;
                 + "as you declare eg `public abstract Property<Integer> getFoo()`, this will automatically "
                 + "make the `foo = 3` groovy syntax work of the box.")
 public final class NonAbstractGradleType extends GradleGuideBugChecker
-        implements BugChecker.ClassTreeMatcher, BugChecker.MethodInvocationTreeMatcher, BugChecker.MethodTreeMatcher {
+        implements BugChecker.ClassTreeMatcher,
+                BugChecker.MethodInvocationTreeMatcher,
+                BugChecker.MethodTreeMatcher,
+                BugChecker.VariableTreeMatcher {
     private static final Matcher<ClassTree> IS_TASK = Matchers.isSubtypeOf("org.gradle.api.Task");
     private static final Matcher<ExpressionTree> IS_EXTENSION_CREATE = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.plugins.ExtensionContainer")
@@ -69,6 +74,11 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
                     + "convention is required for Gradle to recognize and manage the property, enabling automatic "
                     + "property wiring and Groovy DSL support, this will automatically this will make the `foo = 3` "
                     + "groovy syntax work of the box.";
+
+    private static final String PROPERTY_FIELD_MSG = "Do not declare Property fields directly on Tasks or Extensions. "
+            + "Instead, declare an abstract getter method, e.g., 'public abstract Property<String> getFoo();'. This "
+            + "enables Gradle to inject the property implementation automatically, removes boilerplate, and supports "
+            + "the Groovy DSL (e.g. `foo = 3`).";
 
     private static final Set<String> SUPPORTED_PROPERTY_TYPES = Set.of(
             "org.gradle.api.provider.Property",
@@ -125,6 +135,27 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
     }
 
     @Override
+    public Description matchVariable(VariableTree tree, VisitorState state) {
+        ClassTree enclosingClass = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
+        if (enclosingClass == null) {
+            return Description.NO_MATCH;
+        }
+
+        if (!IS_TASK.matches(enclosingClass, state)) {
+            return Description.NO_MATCH;
+        }
+
+        Type varType = ASTHelpers.getType(tree);
+        if (varType != null
+                && SUPPORTED_PROPERTY_TYPES.contains(
+                        varType.tsym.getQualifiedName().toString())) {
+            return buildDescription(tree).setMessage(PROPERTY_FIELD_MSG).build();
+        }
+
+        return Description.NO_MATCH;
+    }
+
+    @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         // We have to do our checks on Extensions where they are created rather than on the Extension types themselves
         // This is because Extension types do not extend a class or implement an interface. There's no way to tell if
@@ -148,13 +179,32 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
         }
         Type extensionType = extensionTypeOpt.get();
 
-        // Check: must be abstract, not interface
         if (!(isAbstract(extensionType.tsym) || extensionType.isInterface())) {
             return buildDescription(tree).build();
         }
 
         ClassSymbol extSym = (ClassSymbol) extensionType.tsym;
-        // Stream over the symbol table for methods
+        if (hasPropertyField(extSym)) {
+            return buildDescription(tree).setMessage(PROPERTY_FIELD_MSG).build();
+        }
+
+        return checkManagedPropertyGetters(extSym, tree, state);
+    }
+
+    private static boolean hasPropertyField(ClassSymbol extSym) {
+        return StreamSupport.stream(extSym.members().getSymbols().spliterator(), false)
+                .filter(memberSym -> memberSym instanceof VarSymbol)
+                .map(memberSym -> (VarSymbol) memberSym)
+                .anyMatch(varSym -> {
+                    Type fieldType = varSym.type;
+                    return fieldType != null
+                            && fieldType.tsym != null
+                            && SUPPORTED_PROPERTY_TYPES.contains(
+                                    fieldType.tsym.getQualifiedName().toString());
+                });
+    }
+
+    private Description checkManagedPropertyGetters(ClassSymbol extSym, MethodInvocationTree tree, VisitorState state) {
         return StreamSupport.stream(extSym.members().getSymbols().spliterator(), false)
                 .filter(memberSym -> memberSym instanceof MethodSymbol)
                 .map(memberSym -> (MethodSymbol) memberSym)

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java
@@ -137,9 +137,7 @@ public final class NonAbstractGradleType extends GradleGuideBugChecker
 
         // Check: must be abstract, not interface
         if (!(isTypeAbstract(extensionType) || extensionType.isInterface())) {
-            return buildDescription(tree)
-                    .setMessage("Gradle managed Extension types must be abstract classes.")
-                    .build();
+            return buildDescription(tree).build();
         }
 
         ClassSymbol extSym = (ClassSymbol) extensionType.tsym;

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -219,7 +219,7 @@ class NonAbstractGradleTypeTest {
                             public class FooPlugin implements Plugin<Project> {
                                 @Override
                                 public void apply(Project project) {
-                                    // BUG: Diagnostic contains: must be named starting with 'get'
+                                    // BUG: Diagnostic contains: must start with 'get'
                                     project.getExtensions().create("foo", FooExtension.class);
                                 }
                             }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -194,7 +194,7 @@ class NonAbstractGradleTypeTest {
                             public class FooPlugin implements Plugin<Project> {
                                 @Override
                                 public void apply(Project project) {
-                                    // BUG: Diagnostic contains: managed property getter in Extension must be abstract
+                                    // BUG: Diagnostic contains: managed property getter methods must be abstract
                                     project.getExtensions().create("foo", FooExtension.class);
                                 }
                             }
@@ -219,7 +219,7 @@ class NonAbstractGradleTypeTest {
                             public class FooPlugin implements Plugin<Project> {
                                 @Override
                                 public void apply(Project project) {
-                                    // BUG: Diagnostic contains: must start with 'get'
+                                    // BUG: Diagnostic contains: methods must be named starting with 'get'
                                     project.getExtensions().create("foo", FooExtension.class);
                                 }
                             }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -85,6 +85,21 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
+        void abstract_task_with_non_abstract_property_getter_and_incorrect_naming_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: should be named starting with 'get'
+                        // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
+                        public Property<String> foo() { return null; }
+                    }
+                    """);
+        }
+
+        @Test
         void abstract_task_with_abstract_property_getter_is_fine() {
             test(
                     """

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -65,7 +65,7 @@ class NonAbstractGradleTypeTest {
                     import org.gradle.api.DefaultTask;
                     import org.gradle.api.provider.Property;
                     abstract class Test extends DefaultTask {
-                        // BUG: Diagnostic contains: must be abstract
+                        // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
                         public Property<String> getFoo() { return null; }
                     }
                     """);
@@ -194,7 +194,7 @@ class NonAbstractGradleTypeTest {
                             public class FooPlugin implements Plugin<Project> {
                                 @Override
                                 public void apply(Project project) {
-                                    // BUG: Diagnostic contains: managed property getter methods must be abstract
+                                    // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
                                     project.getExtensions().create("foo", FooExtension.class);
                                 }
                             }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -78,7 +78,7 @@ class NonAbstractGradleTypeTest {
                     import org.gradle.api.DefaultTask;
                     import org.gradle.api.provider.Property;
                     abstract class Test extends DefaultTask {
-                        // BUG: Diagnostic contains: must be named starting with 'get'
+                        // BUG: Diagnostic contains: should be named starting with 'get'
                         public abstract Property<String> name();
                     }
                     """);
@@ -194,7 +194,7 @@ class NonAbstractGradleTypeTest {
                             public class FooPlugin implements Plugin<Project> {
                                 @Override
                                 public void apply(Project project) {
-                                    // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
+                                    // BUG: Diagnostic contains: should be declared abstract
                                     project.getExtensions().create("foo", FooExtension.class);
                                 }
                             }
@@ -219,7 +219,7 @@ class NonAbstractGradleTypeTest {
                             public class FooPlugin implements Plugin<Project> {
                                 @Override
                                 public void apply(Project project) {
-                                    // BUG: Diagnostic contains: methods must be named starting with 'get'
+                                    // BUG: Diagnostic contains: should be named starting with 'get'
                                     project.getExtensions().create("foo", FooExtension.class);
                                 }
                             }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -72,6 +72,32 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
+        void abstract_task_with_non_abstract_DomainObjectCollection_getter_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.NamedDomainObjectContainer;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
+                        public NamedDomainObjectContainer<String> getFoo() { return null; }
+                    }
+                    """);
+        }
+
+        @Test
+        void abstract_task_with_non_abstract_FileCollection_getter_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.file.ConfigurableFileTree;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
+                        public ConfigurableFileTree getFoo() { return null; }
+                    }
+                    """);
+        }
+
+        @Test
         void abstract_task_with_provider_getter_not_starting_with_get_should_fail() {
             test(
                     """

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -57,6 +57,67 @@ class NonAbstractGradleTypeTest {
                     interface TestTask extends Task {}
                     """);
         }
+
+        @Test
+        void abstract_task_with_non_abstract_property_getter_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: must be abstract
+                        public Property<String> getFoo() { return null; }
+                    }
+                    """);
+        }
+
+        @Test
+        void abstract_task_with_property_getter_not_starting_with_get_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: must be named starting with 'get'
+                        public abstract Property<String> name();
+                    }
+                    """);
+        }
+
+        @Test
+        void abstract_task_with_abstract_property_getter_is_fine() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        public abstract Property<String> getFoo();
+                    }
+                    """);
+        }
+
+        @Test
+        void abstract_task_with_non_property_getter_is_fine() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    abstract class Test extends DefaultTask {
+                        public String getSomething() { return "hello"; }
+                    }
+                    """);
+        }
+
+        @Test
+        void abstract_task_with_property_getter_with_parameter_is_fine() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        public Property<String> getFoo(String ignored) { return null; }
+                    }
+                    """);
+        }
     }
 
     @Nested
@@ -115,12 +176,146 @@ class NonAbstractGradleTypeTest {
                     .expectNoDiagnostics()
                     .doTest();
         }
+
+        @Test
+        void extension_with_non_abstract_property_getter_should_fail() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            "import org.gradle.api.provider.Property;",
+                            "abstract class FooExtension {",
+                            "    public Property<String> getFoo() { return null; }",
+                            "}")
+                    .addSourceLines(
+                            "FooPlugin.java",
+                            """
+                            import org.gradle.api.Plugin;
+                            import org.gradle.api.Project;
+                            public class FooPlugin implements Plugin<Project> {
+                                @Override
+                                public void apply(Project project) {
+                                    // BUG: Diagnostic contains: managed property getter in Extension must be abstract
+                                    project.getExtensions().create("foo", FooExtension.class);
+                                }
+                            }
+                            """)
+                    .doTest();
+        }
+
+        @Test
+        void extension_with_property_getter_not_starting_with_get_should_fail() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            "import org.gradle.api.provider.Property;",
+                            "abstract class FooExtension {",
+                            "    public abstract Property<String> name();",
+                            "}")
+                    .addSourceLines(
+                            "FooPlugin.java",
+                            """
+                            import org.gradle.api.Plugin;
+                            import org.gradle.api.Project;
+                            public class FooPlugin implements Plugin<Project> {
+                                @Override
+                                public void apply(Project project) {
+                                    // BUG: Diagnostic contains: must be named starting with 'get'
+                                    project.getExtensions().create("foo", FooExtension.class);
+                                }
+                            }
+                            """)
+                    .doTest();
+        }
+
+        @Test
+        void extension_with_abstract_property_getter_is_fine() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            "import org.gradle.api.provider.Property;",
+                            "abstract class FooExtension {",
+                            "    public abstract Property<String> getFoo();",
+                            "}")
+                    .addSourceLines(
+                            "FooPlugin.java",
+                            """
+                            import org.gradle.api.Plugin;
+                            import org.gradle.api.Project;
+                            public class FooPlugin implements Plugin<Project> {
+                                @Override
+                                public void apply(Project project) {
+                                    project.getExtensions().create("foo", FooExtension.class);
+                                }
+                            }
+                            """)
+                    .expectNoDiagnostics()
+                    .doTest();
+        }
+
+        @Test
+        void extension_with_non_property_getter_is_fine() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            "abstract class FooExtension {",
+                            "    public String getSomething() { return \"hello\"; }",
+                            "}")
+                    .addSourceLines(
+                            "FooPlugin.java",
+                            """
+                            import org.gradle.api.Plugin;
+                            import org.gradle.api.Project;
+                            public class FooPlugin implements Plugin<Project> {
+                                @Override
+                                public void apply(Project project) {
+                                    project.getExtensions().create("foo", FooExtension.class);
+                                }
+                            }
+                            """)
+                    .expectNoDiagnostics()
+                    .doTest();
+        }
+
+        @Test
+        void extension_with_property_getter_with_parameter_is_fine() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            "import org.gradle.api.provider.Property;",
+                            "abstract class FooExtension {",
+                            "    public Property<String> getFoo(String ignored) { return null; }",
+                            "}")
+                    .addSourceLines(
+                            "FooPlugin.java",
+                            """
+                            import org.gradle.api.Plugin;
+                            import org.gradle.api.Project;
+                            public class FooPlugin implements Plugin<Project> {
+                                @Override
+                                public void apply(Project project) {
+                                    project.getExtensions().create("foo", FooExtension.class);
+                                }
+                            }
+                            """)
+                    .expectNoDiagnostics()
+                    .doTest();
+        }
     }
 
     @Test
     void non_abstract_other_type_is_fine() {
         test("""
                 class SomethingElse {}
+                """);
+    }
+
+    @Test
+    void unrelated_abstract_class_with_property_getter_is_fine() {
+        test(
+                """
+                abstract class NotATaskOrExtension {
+                    public abstract String getFoo();
+                }
                 """);
     }
 

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -59,20 +59,20 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void abstract_task_with_non_abstract_property_getter_should_fail() {
+        void abstract_task_with_non_abstract_provider_getter_should_fail() {
             test(
                     """
                     import org.gradle.api.DefaultTask;
-                    import org.gradle.api.provider.Property;
+                    import org.gradle.api.file.RegularFileProperty;
                     abstract class Test extends DefaultTask {
                         // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
-                        public Property<String> getFoo() { return null; }
+                        public RegularFileProperty getFoo() { return null; }
                     }
                     """);
         }
 
         @Test
-        void abstract_task_with_property_getter_not_starting_with_get_should_fail() {
+        void abstract_task_with_provider_getter_not_starting_with_get_should_fail() {
             test(
                     """
                     import org.gradle.api.DefaultTask;
@@ -85,34 +85,19 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void abstract_task_with_non_abstract_property_getter_and_incorrect_naming_should_fail() {
+        void abstract_task_with_abstract_provider_getter_is_fine() {
             test(
                     """
                     import org.gradle.api.DefaultTask;
-                    import org.gradle.api.provider.Property;
-
+                    import org.gradle.api.provider.SetProperty;
                     abstract class Test extends DefaultTask {
-                        // BUG: Diagnostic contains: should be named starting with 'get'
-                        // BUG: Diagnostic contains: Properties on Tasks or Extensions should be declared abstract
-                        public Property<String> foo() { return null; }
+                        public abstract SetProperty<String> getFoo();
                     }
                     """);
         }
 
         @Test
-        void abstract_task_with_abstract_property_getter_is_fine() {
-            test(
-                    """
-                    import org.gradle.api.DefaultTask;
-                    import org.gradle.api.provider.Property;
-                    abstract class Test extends DefaultTask {
-                        public abstract Property<String> getFoo();
-                    }
-                    """);
-        }
-
-        @Test
-        void abstract_task_with_non_property_getter_is_fine() {
+        void abstract_task_with_non_provider_getter_is_fine() {
             test(
                     """
                     import org.gradle.api.DefaultTask;
@@ -123,7 +108,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void abstract_task_with_property_getter_with_parameter_is_fine() {
+        void abstract_task_with_provider_getter_with_parameter_is_fine() {
             test(
                     """
                     import org.gradle.api.DefaultTask;
@@ -135,7 +120,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void abstract_task_with_property_field_should_fail() {
+        void abstract_task_with_provider_field_should_fail() {
             test(
                     """
                     import org.gradle.api.DefaultTask;
@@ -210,7 +195,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void extension_with_non_abstract_property_getter_should_fail() {
+        void extension_with_non_abstract_provider_getter_should_fail() {
             compilationTestHelper
                     .addSourceLines(
                             "FooExtension.java",
@@ -235,7 +220,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void extension_with_property_getter_not_starting_with_get_should_fail() {
+        void extension_with_provider_getter_not_starting_with_get_should_fail() {
             compilationTestHelper
                     .addSourceLines(
                             "FooExtension.java",
@@ -260,7 +245,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void extension_with_abstract_property_getter_is_fine() {
+        void extension_with_abstract_provider_getter_is_fine() {
             compilationTestHelper
                     .addSourceLines(
                             "FooExtension.java",
@@ -285,7 +270,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void extension_with_non_property_getter_is_fine() {
+        void extension_with_non_provider_getter_is_fine() {
             compilationTestHelper
                     .addSourceLines(
                             "FooExtension.java",
@@ -309,7 +294,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void extension_with_property_getter_with_parameter_is_fine() {
+        void extension_with_provider_getter_with_parameter_is_fine() {
             compilationTestHelper
                     .addSourceLines(
                             "FooExtension.java",
@@ -334,7 +319,7 @@ class NonAbstractGradleTypeTest {
         }
 
         @Test
-        void abstract_extension_with_property_field_should_fail() {
+        void abstract_extension_with_provider_field_should_fail() {
             compilationTestHelper
                     .addSourceLines(
                             "FooExtension.java",
@@ -370,7 +355,7 @@ class NonAbstractGradleTypeTest {
     }
 
     @Test
-    void unrelated_abstract_class_with_property_getter_is_fine() {
+    void unrelated_abstract_class_with_provider_getter_is_fine() {
         test(
                 """
                 abstract class NotATaskOrExtension {
@@ -380,7 +365,7 @@ class NonAbstractGradleTypeTest {
     }
 
     @Test
-    void unrelated_class_with_property_getter_is_fine() {
+    void unrelated_class_with_provider_getter_is_fine() {
         test(
                 """
                 import org.gradle.api.provider.Property;
@@ -391,7 +376,7 @@ class NonAbstractGradleTypeTest {
     }
 
     @Test
-    void unrelated_class_with_property_field_is_fine() {
+    void unrelated_class_with_provider_field_is_fine() {
         test(
                 """
                 import org.gradle.api.provider.Property;

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -118,6 +118,23 @@ class NonAbstractGradleTypeTest {
                     }
                     """);
         }
+
+        @Test
+        void abstract_task_with_property_field_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: Do not declare Property fields directly on Tasks or Extensions
+                        private final Property<String> foo;
+                        public Test() {
+                            this.foo = getProject().getObjects().property(String.class);
+                        }
+                    }
+                    """);
+        }
     }
 
     @Nested
@@ -300,6 +317,34 @@ class NonAbstractGradleTypeTest {
                     .expectNoDiagnostics()
                     .doTest();
         }
+
+        @Test
+        void abstract_extension_with_property_field_should_fail() {
+            compilationTestHelper
+                    .addSourceLines(
+                            "FooExtension.java",
+                            "import org.gradle.api.provider.Property;",
+                            "abstract class FooExtension {",
+                            "    private final Property<String> foo;",
+                            "    public FooExtension(org.gradle.api.Project project) {",
+                            "        this.foo = project.getObjects().property(String.class);",
+                            "    }",
+                            "}")
+                    .addSourceLines(
+                            "FooPlugin.java",
+                            """
+                            import org.gradle.api.Plugin;
+                            import org.gradle.api.Project;
+                            public class FooPlugin implements Plugin<Project> {
+                                @Override
+                                public void apply(Project project) {
+                                    // BUG: Diagnostic contains: Do not declare Property fields directly
+                                    project.getExtensions().create("foo", FooExtension.class);
+                                }
+                            }
+                            """)
+                    .doTest();
+        }
     }
 
     @Test
@@ -324,8 +369,22 @@ class NonAbstractGradleTypeTest {
         test(
                 """
                 import org.gradle.api.provider.Property;
-                abstract class Test {
+                abstract class NotATaskOrExtension {
                     public Property<String> getFoo() { return null; }
+                }
+                """);
+    }
+
+    @Test
+    void unrelated_class_with_property_field_is_fine() {
+        test(
+                """
+                import org.gradle.api.provider.Property;
+                class NotATaskOrExtension {
+                    private final Property<String> foo;
+                    public NotATaskOrExtension(Property<String> foo) {
+                        this.foo = foo;
+                    }
                 }
                 """);
     }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleTypeTest.java
@@ -319,6 +319,17 @@ class NonAbstractGradleTypeTest {
                 """);
     }
 
+    @Test
+    void unrelated_class_with_property_getter_is_fine() {
+        test(
+                """
+                import org.gradle.api.provider.Property;
+                abstract class Test {
+                    public Property<String> getFoo() { return null; }
+                }
+                """);
+    }
+
     private void test(@Language("Java") String source) {
         compilationTestHelper.addSourceLines("Test.java", source).doTest();
     }


### PR DESCRIPTION
## Before this PR
Had no Errorprone to check if task and extension properties where abstract and started with get - see https://github.com/palantir/gradle-idea-configuration/pull/20/files#r2084653438

## After this PR
Expanded `NonAbstractGradleType` to add ability to detect if gradle managed properties are abstract and start with get
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expanded NonAbstractGradleType to add ability to detect if gradle managed properties are abstract and start with get
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

