### PR TITLE
Errorprone to check that abstract methods in Tasks or Extensions that return Gradle managed types start with 'get'

### DIFF
--- a/changelog/@unreleased/pr-125.v2.yml
+++ b/changelog/@unreleased/pr-125.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Errorprone to check that abstract methods in Tasks or Extensions that
+    return Gradle managed types start with 'get'
+  links:
+  - https://github.com/palantir/gradle-guide/pull/125

--- a/errorprones.md
+++ b/errorprones.md
@@ -28,6 +28,22 @@ When registering a new `Task`, `Configuration` or other Gradle domain type, use 
 <tr>
 <td>
 
+<a id="GradleManagedTypeGetPrefix" href="guide/managed-types-and-properties.md">`GradleManagedTypeGetPrefix`</a>
+
+</td>
+<td>
+<a href="guide/managed-types-and-properties.md">Please read</a>
+</td>
+<td>
+
+Abstract methods in Tasks or Extensions that return Gradle managed types should start with 'get'. This naming convention ensures consistency and allows Gradle to handle property injection correctly. For example, use 'public abstract Property<String> getFoo();' instead of 'public abstract Property<String> foo();'. This enables Gradle to inject the property implementation automatically, removes boilerplate, and supports the Groovy DSL (e.g. `foo = 3`).
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 <a id="GradleTypesAsFields" href="guide/managed-types-and-properties.md">`GradleTypesAsFields`</a>
 
 </td>

--- a/errorprones.md
+++ b/errorprones.md
@@ -36,7 +36,7 @@ When registering a new `Task`, `Configuration` or other Gradle domain type, use 
 </td>
 <td>
 
-Abstract methods in Tasks or Extensions that return Gradle managed types should start with 'get'. This naming convention ensures consistency and allows Gradle to handle property injection correctly. For example, use 'public abstract Property<String> getFoo();' instead of 'public abstract Property<String> foo();'. This enables Gradle to inject the property implementation automatically, removes boilerplate, and supports the Groovy DSL (e.g. `foo = 3`).
+Abstract methods in Tasks or Extensions that return Gradle managed types should start with 'get'. This allows Gradle to handle property injection correctly. For example, use 'public abstract Property<String> getFoo();' instead of 'public abstract Property<String> foo();'. This enables Gradle to inject the property implementation automatically, removes boilerplate, and supports the Groovy DSL (e.g. `foo = 3`).
 
 </td>
 </tr>

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefix.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefix.java
@@ -29,17 +29,19 @@ import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.VariableTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
-import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import javax.lang.model.element.Modifier;
 
 @AutoService(BugChecker.class)
-@BugPattern(severity = SeverityLevel.ERROR, summary = GradleTypesAsFields.SUMMARY)
-public final class GradleTypesAsFields extends GradleGuideBugChecker
-        implements BugChecker.VariableTreeMatcher, ExtensionClassMatcher {
+@BugPattern(severity = SeverityLevel.ERROR, summary = GradleManagedTypeGetPrefix.SUMMARY)
+public final class GradleManagedTypeGetPrefix extends GradleGuideBugChecker
+        implements BugChecker.MethodTreeMatcher, ExtensionClassMatcher {
     private static final Matcher<ClassTree> IS_TASK = Matchers.isSubtypeOf("org.gradle.api.Task");
     private static final Supplier<Type> PROVIDER_TYPE_SUPPLIER =
             Suppliers.typeFromString("org.gradle.api.provider.Provider");
@@ -49,14 +51,16 @@ public final class GradleTypesAsFields extends GradleGuideBugChecker
             Suppliers.typeFromString("org.gradle.api.file.FileCollection");
 
     public static final String SUMMARY =
-            "Do not declare Properties, FileCollections and other Gradle managed types as fields directly on Tasks or "
-                    + "Extensions. Instead, declare an abstract getter method, e.g., 'public abstract Property<String> "
-                    + "getFoo();'. This enables Gradle to inject the property implementation automatically, removes "
-                    + "boilerplate, and supports the Groovy DSL (e.g. `foo = 3`).";
+            "Abstract methods in Tasks or Extensions that return Gradle managed types should start with 'get'. "
+                    + "This naming convention ensures consistency and allows Gradle to handle property injection "
+                    + "correctly. For example, use 'public abstract Property<String> getFoo();' instead of 'public "
+                    + "abstract Property<String> foo();'. This enables Gradle to inject the property implementation "
+                    + "automatically, removes boilerplate, and supports the Groovy DSL (e.g. `foo = 3`).";
 
     @Override
-    public Description matchVariable(VariableTree tree, VisitorState state) {
-        if (!(state.getPath().getParentPath().getLeaf() instanceof ClassTree enclosingClass)) {
+    public Description matchMethod(MethodTree method, VisitorState state) {
+        ClassTree enclosingClass = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
+        if (enclosingClass == null) {
             return Description.NO_MATCH;
         }
 
@@ -64,9 +68,16 @@ public final class GradleTypesAsFields extends GradleGuideBugChecker
             return Description.NO_MATCH;
         }
 
-        Type varType = ASTHelpers.getType(tree);
-        if (varType != null && isManagedPropertyType(varType, state)) {
-            return describeMatch(tree);
+        if (!isManagedPropertyType(ASTHelpers.getType(method.getReturnType()), state)) {
+            return Description.NO_MATCH;
+        }
+
+        if (!isAbstract(ASTHelpers.getSymbol(method))) {
+            return Description.NO_MATCH;
+        }
+
+        if (!method.getName().toString().startsWith("get")) {
+            return describeMatch(method);
         }
 
         return Description.NO_MATCH;
@@ -75,24 +86,32 @@ public final class GradleTypesAsFields extends GradleGuideBugChecker
     @Override
     public Description matchExtensionClass(
             ClassSymbol extensionClass, MethodInvocationTree extensionContainerCreateTree, VisitorState state) {
-        String fieldNames = StreamSupport.stream(
+
+        String methodNames = StreamSupport.stream(
                         extensionClass.members().getSymbols().spliterator(), false)
-                .filter(memberSym -> memberSym instanceof VarSymbol)
-                .map(memberSym -> (VarSymbol) memberSym)
-                .filter(varSym -> varSym.owner.equals(extensionClass))
-                .filter(varSym -> isManagedPropertyType(varSym.type, state))
-                .map(varSym -> varSym.getSimpleName().toString())
+                .filter(memberSym -> memberSym instanceof MethodSymbol)
+                .map(memberSym -> (MethodSymbol) memberSym)
+                .filter(methodSym -> methodSym.owner.equals(extensionClass))
+                .filter(GradleManagedTypeGetPrefix::isAbstract)
+                .filter(methodSym -> isManagedPropertyType(methodSym.getReturnType(), state))
+                .map(MethodSymbol::getSimpleName)
+                .filter(simpleName -> !simpleName.toString().startsWith("get"))
+                .map(Object::toString)
                 .collect(Collectors.joining(", "));
 
-        if (!fieldNames.isEmpty()) {
+        if (!methodNames.isEmpty()) {
             return buildDescription(extensionContainerCreateTree)
                     .setMessage("Within the " + extensionClass.getSimpleName()
-                            + " extension, the following declared fields are not abstract: " + fieldNames + "\n"
+                            + " extension, the following methods do not start with 'get': " + methodNames + "\n"
                             + SUMMARY)
                     .build();
         }
 
         return Description.NO_MATCH;
+    }
+
+    private static boolean isAbstract(Symbol symbol) {
+        return symbol != null && symbol.getModifiers().contains(Modifier.ABSTRACT);
     }
 
     private static boolean isManagedPropertyType(Type type, VisitorState state) {

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefix.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefix.java
@@ -24,16 +24,14 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.suppliers.Supplier;
-import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
+import com.palantir.gradle.guide.errorprone.utils.GradleManagedTypes;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
-import com.sun.tools.javac.code.Type;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.lang.model.element.Modifier;
@@ -43,12 +41,6 @@ import javax.lang.model.element.Modifier;
 public final class GradleManagedTypeGetPrefix extends GradleGuideBugChecker
         implements BugChecker.MethodTreeMatcher, ExtensionClassMatcher {
     private static final Matcher<ClassTree> IS_TASK = Matchers.isSubtypeOf("org.gradle.api.Task");
-    private static final Supplier<Type> PROVIDER_TYPE_SUPPLIER =
-            Suppliers.typeFromString("org.gradle.api.provider.Provider");
-    private static final Supplier<Type> DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER =
-            Suppliers.typeFromString("org.gradle.api.DomainObjectCollection");
-    private static final Supplier<Type> FILE_COLLECTION_TYPE_SUPPLIER =
-            Suppliers.typeFromString("org.gradle.api.file.FileCollection");
 
     public static final String SUMMARY =
             "Abstract methods in Tasks or Extensions that return Gradle managed types should start with 'get'. "
@@ -69,7 +61,7 @@ public final class GradleManagedTypeGetPrefix extends GradleGuideBugChecker
             return Description.NO_MATCH;
         }
 
-        if (!isManagedPropertyType(ASTHelpers.getType(method.getReturnType()), state)) {
+        if (!GradleManagedTypes.isManagedType(ASTHelpers.getType(method.getReturnType()), state)) {
             return Description.NO_MATCH;
         }
 
@@ -94,7 +86,7 @@ public final class GradleManagedTypeGetPrefix extends GradleGuideBugChecker
                 .map(memberSym -> (MethodSymbol) memberSym)
                 .filter(methodSym -> methodSym.owner.equals(extensionClass))
                 .filter(GradleManagedTypeGetPrefix::isAbstract)
-                .filter(methodSym -> isManagedPropertyType(methodSym.getReturnType(), state))
+                .filter(methodSym -> GradleManagedTypes.isManagedType(methodSym.getReturnType(), state))
                 .map(MethodSymbol::getSimpleName)
                 .filter(simpleName -> !simpleName.toString().startsWith("get"))
                 .map(Object::toString)
@@ -113,24 +105,6 @@ public final class GradleManagedTypeGetPrefix extends GradleGuideBugChecker
 
     private static boolean isAbstract(Symbol symbol) {
         return symbol != null && symbol.getModifiers().contains(Modifier.ABSTRACT);
-    }
-
-    private static boolean isManagedPropertyType(Type type, VisitorState state) {
-        return isSubtypeOfProvider(type, state)
-                || isSubtypeOfDomainObjectCollection(type, state)
-                || isSubtypeOfFileCollection(type, state);
-    }
-
-    private static boolean isSubtypeOfProvider(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, PROVIDER_TYPE_SUPPLIER.get(state), state);
-    }
-
-    private static boolean isSubtypeOfDomainObjectCollection(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER.get(state), state);
-    }
-
-    private static boolean isSubtypeOfFileCollection(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, FILE_COLLECTION_TYPE_SUPPLIER.get(state), state);
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefix.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefix.java
@@ -52,10 +52,11 @@ public final class GradleManagedTypeGetPrefix extends GradleGuideBugChecker
 
     public static final String SUMMARY =
             "Abstract methods in Tasks or Extensions that return Gradle managed types should start with 'get'. "
-                    + "This naming convention ensures consistency and allows Gradle to handle property injection "
-                    + "correctly. For example, use 'public abstract Property<String> getFoo();' instead of 'public "
-                    + "abstract Property<String> foo();'. This enables Gradle to inject the property implementation "
-                    + "automatically, removes boilerplate, and supports the Groovy DSL (e.g. `foo = 3`).";
+                    + "This allows Gradle to handle property injection correctly. For example, use "
+                    + "'public abstract Property<String> getFoo();' instead of "
+                    + "'public abstract Property<String> foo();'. This enables Gradle to inject the property "
+                    + "implementation automatically, removes boilerplate, and supports the Groovy DSL "
+                    + "(e.g. `foo = 3`).";
 
     @Override
     public Description matchMethod(MethodTree method, VisitorState state) {

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleTypesAsFields.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleTypesAsFields.java
@@ -24,9 +24,8 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.suppliers.Supplier;
-import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
+import com.palantir.gradle.guide.errorprone.utils.GradleManagedTypes;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.VariableTree;
@@ -41,12 +40,6 @@ import java.util.stream.StreamSupport;
 public final class GradleTypesAsFields extends GradleGuideBugChecker
         implements BugChecker.VariableTreeMatcher, ExtensionClassMatcher {
     private static final Matcher<ClassTree> IS_TASK = Matchers.isSubtypeOf("org.gradle.api.Task");
-    private static final Supplier<Type> PROVIDER_TYPE_SUPPLIER =
-            Suppliers.typeFromString("org.gradle.api.provider.Provider");
-    private static final Supplier<Type> DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER =
-            Suppliers.typeFromString("org.gradle.api.DomainObjectCollection");
-    private static final Supplier<Type> FILE_COLLECTION_TYPE_SUPPLIER =
-            Suppliers.typeFromString("org.gradle.api.file.FileCollection");
 
     public static final String SUMMARY =
             "Do not declare Properties, FileCollections and other Gradle managed types as fields directly on Tasks or "
@@ -65,7 +58,7 @@ public final class GradleTypesAsFields extends GradleGuideBugChecker
         }
 
         Type varType = ASTHelpers.getType(tree);
-        if (varType != null && isManagedPropertyType(varType, state)) {
+        if (varType != null && GradleManagedTypes.isManagedType(varType, state)) {
             return describeMatch(tree);
         }
 
@@ -80,7 +73,7 @@ public final class GradleTypesAsFields extends GradleGuideBugChecker
                 .filter(memberSym -> memberSym instanceof VarSymbol)
                 .map(memberSym -> (VarSymbol) memberSym)
                 .filter(varSym -> varSym.owner.equals(extensionClass))
-                .filter(varSym -> isManagedPropertyType(varSym.type, state))
+                .filter(varSym -> GradleManagedTypes.isManagedType(varSym.type, state))
                 .map(varSym -> varSym.getSimpleName().toString())
                 .collect(Collectors.joining(", "));
 
@@ -93,24 +86,6 @@ public final class GradleTypesAsFields extends GradleGuideBugChecker
         }
 
         return Description.NO_MATCH;
-    }
-
-    private static boolean isManagedPropertyType(Type type, VisitorState state) {
-        return isSubtypeOfProvider(type, state)
-                || isSubtypeOfDomainObjectCollection(type, state)
-                || isSubtypeOfFileCollection(type, state);
-    }
-
-    private static boolean isSubtypeOfProvider(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, PROVIDER_TYPE_SUPPLIER.get(state), state);
-    }
-
-    private static boolean isSubtypeOfDomainObjectCollection(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER.get(state), state);
-    }
-
-    private static boolean isSubtypeOfFileCollection(Type type, VisitorState state) {
-        return ASTHelpers.isSubtype(type, FILE_COLLECTION_TYPE_SUPPLIER.get(state), state);
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/GradleManagedTypes.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/GradleManagedTypes.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.utils;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.suppliers.Suppliers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.tools.javac.code.Type;
+
+public final class GradleManagedTypes {
+    private static final Supplier<Type> PROVIDER_TYPE_SUPPLIER =
+            Suppliers.typeFromString("org.gradle.api.provider.Provider");
+    private static final Supplier<Type> DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER =
+            Suppliers.typeFromString("org.gradle.api.DomainObjectCollection");
+    private static final Supplier<Type> FILE_COLLECTION_TYPE_SUPPLIER =
+            Suppliers.typeFromString("org.gradle.api.file.FileCollection");
+
+    public static boolean isManagedType(Type type, VisitorState state) {
+        return isSubtypeOfProvider(type, state)
+                || isSubtypeOfDomainObjectCollection(type, state)
+                || isSubtypeOfFileCollection(type, state);
+    }
+
+    private static boolean isSubtypeOfProvider(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, PROVIDER_TYPE_SUPPLIER.get(state), state);
+    }
+
+    private static boolean isSubtypeOfDomainObjectCollection(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, DOMAIN_OBJECT_COLLECTION_TYPE_SUPPLIER.get(state), state);
+    }
+
+    private static boolean isSubtypeOfFileCollection(Type type, VisitorState state) {
+        return ASTHelpers.isSubtype(type, FILE_COLLECTION_TYPE_SUPPLIER.get(state), state);
+    }
+
+    private GradleManagedTypes() {}
+}

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefixTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/GradleManagedTypeGetPrefixTest.java
@@ -1,0 +1,241 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("MisformattedTestData")
+class GradleManagedTypeGetPrefixTest {
+    private final CompilationTestHelper compilationTestHelper =
+            CompilationTestHelper.newInstance(GradleManagedTypeGetPrefix.class, getClass());
+
+    @Nested
+    class Tasks {
+        @Test
+        void abstract_method_without_get_prefix_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: should start with 'get'
+                        public abstract Property<String> foo();
+                    }
+                    """);
+        }
+
+        @Test
+        void named_domain_abstract_method_without_get_prefix_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.NamedDomainObjectContainer;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: should start with 'get'
+                        public abstract NamedDomainObjectContainer<String> foo();
+                    }
+                    """);
+        }
+
+        @Test
+        void file_collection_abstract_method_without_get_prefix_should_fail() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.file.FileCollection;
+                    abstract class Test extends DefaultTask {
+                        // BUG: Diagnostic contains: should start with 'get'
+                        public abstract FileCollection foo();
+                    }
+                    """);
+        }
+
+        @Test
+        void abstract_method_with_get_prefix_should_be_fine() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        public abstract Property<String> getFoo();
+                    }
+                    """);
+        }
+
+        @Test
+        void non_abstract_method_should_be_fine() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.provider.Property;
+                    abstract class Test extends DefaultTask {
+                        public Property<String> foo() {
+                            return getProject().getObjects().property(String.class);
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void method_returning_non_managed_type_should_be_fine() {
+            test(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    abstract class Test extends DefaultTask {
+                        public abstract String foo();
+                    }
+                    """);
+        }
+    }
+
+    @Nested
+    class Extensions {
+        @Test
+        void abstract_method_without_get_prefix_should_fail() {
+            testExtension(
+                    """
+                    import org.gradle.api.provider.Property;
+                    abstract class FooExtension {
+                        public abstract Property<String> foo();
+                    }
+                    """,
+                    PLUGIN_CODE_BUG);
+        }
+
+        @Test
+        void named_domain_abstract_method_without_get_prefix_should_fail() {
+            testExtension(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.NamedDomainObjectContainer;
+                    abstract class FooExtension {
+                        public abstract NamedDomainObjectContainer<String> foo();
+                    }
+                    """,
+                    PLUGIN_CODE_BUG);
+        }
+
+        @Test
+        void file_collection_abstract_method_without_get_prefix_should_fail() {
+            testExtension(
+                    """
+                    import org.gradle.api.DefaultTask;
+                    import org.gradle.api.file.FileCollection;
+                    abstract class FooExtension {
+                        public abstract FileCollection foo();
+                    }
+                    """,
+                    PLUGIN_CODE_BUG);
+        }
+
+        @Test
+        void abstract_method_with_get_prefix_should_be_fine() {
+            testExtension(
+                    """
+                    import org.gradle.api.provider.Property;
+                    abstract class FooExtension {
+                        public abstract Property<String> getFoo();
+                    }
+                    """,
+                    PLUGIN_CODE_NO_BUG);
+        }
+
+        @Test
+        void non_abstract_method_should_be_fine() {
+            testExtension(
+                    """
+                    import org.gradle.api.provider.Property;
+                    abstract class FooExtension {
+                        public Property<String> foo() {
+                            return null;
+                        }
+                    }
+                    """,
+                    PLUGIN_CODE_NO_BUG);
+        }
+
+        @Test
+        void method_returning_non_managed_type_should_be_fine() {
+            testExtension(
+                    """
+                    abstract class FooExtension {
+                        public abstract String foo();
+                    }
+                    """,
+                    PLUGIN_CODE_NO_BUG);
+        }
+
+        @Language("Java")
+        private static final String PLUGIN_CODE_BUG =
+                """
+        import org.gradle.api.Plugin;
+        import org.gradle.api.Project;
+        public class FooPlugin implements Plugin<Project> {
+            @Override
+            public void apply(Project project) {
+                // BUG: Diagnostic contains: should start with 'get'
+                project.getExtensions().create("foo", FooExtension.class);
+            }
+        }
+        """;
+
+        @Language("Java")
+        private static final String PLUGIN_CODE_NO_BUG =
+                """
+        import org.gradle.api.Plugin;
+        import org.gradle.api.Project;
+        public class FooPlugin implements Plugin<Project> {
+            @Override
+            public void apply(Project project) {
+                project.getExtensions().create("foo", FooExtension.class);
+            }
+        }
+        """;
+    }
+
+    @Test
+    void non_abstract_other_type_is_fine() {
+        test(
+                """
+            import org.gradle.api.provider.Property;
+            abstract class NotATaskOrExtension {
+                private final Property<String> foo = null;
+                NotATaskOrExtension() {}
+                private void bar() {
+                    Property<String> local = null;
+                }
+                class Inner {
+                    private final Property<String> inner = null;
+                }
+                public abstract Property<String> foo();
+            }
+            """);
+    }
+
+    private void test(@Language("Java") String source) {
+        compilationTestHelper.addSourceLines("Test.java", source).doTest();
+    }
+
+    private void testExtension(@Language("Java") String extensionSource, @Language("Java") String pluginCode) {
+        compilationTestHelper
+                .addSourceLines("FooExtension.java", extensionSource)
+                .addSourceLines("FooPlugin.java", pluginCode)
+                .doTest();
+    }
+}


### PR DESCRIPTION
## Before this PR
Had no error prone to ensure this gradle style

## After this PR
Now if a method that is in a task or extension and is abstract does not start with get we add an error prone e.g.

```
public abstract Property<String> foo()
```

would result in an error prone

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Errorprone to check that abstract methods in Tasks or Extensions that return Gradle managed types start with 'get'
==COMMIT_MSG==

## Possible downsides?
It is not always true that get should be prefixed - but in these rare situations it can be suppressed
