### PR TITLE
Ensure that extensions are only added via `.create`

### DIFF
--- a/changelog/@unreleased/pr-127.v2.yml
+++ b/changelog/@unreleased/pr-127.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ensure that extensions are only added via `.create`
+  links:
+  - https://github.com/palantir/gradle-guide/pull/127

--- a/errorprones.md
+++ b/errorprones.md
@@ -36,7 +36,7 @@ When registering a new `Task`, `Configuration` or other Gradle domain type, use 
 </td>
 <td>
 
-Gradle extensions should be registered using `create` rather than by constructing and passing a new instance to `add`. `create` ensures that Gradle manages the extension's lifecycle, type, and dependency injection correctly, while `add` with a manually constructed instance can lead to misconfigured extensions and bypasses Gradle's internal management.
+Gradle extensions should be registered using `create` rather than by constructing and passing a new instance to `add`. Using `create` enables Gradle to properly manage the extension's type. Manual construction with `add` can interfere with certain error-prone checks.
 
 </td>
 </tr>

--- a/errorprones.md
+++ b/errorprones.md
@@ -28,6 +28,22 @@ When registering a new `Task`, `Configuration` or other Gradle domain type, use 
 <tr>
 <td>
 
+<a id="ExtensionsUseCreate" href="guide/managed-types-and-properties.md">`ExtensionsUseCreate`</a>
+
+</td>
+<td>
+<a href="guide/managed-types-and-properties.md">Please read</a>
+</td>
+<td>
+
+Gradle extensions should be registered using `create` rather than by constructing and passing a new instance to `add`. `create` ensures that Gradle manages the extension's lifecycle, type, and dependency injection correctly, while `add` with a manually constructed instance can lead to misconfigured extensions and bypasses Gradle's internal management.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 <a id="GradleManagedTypeGetPrefix" href="guide/managed-types-and-properties.md">`GradleManagedTypeGetPrefix`</a>
 
 </td>

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreate.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreate.java
@@ -33,8 +33,10 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.util.Name;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -44,9 +46,8 @@ import java.util.stream.Stream;
 @AutoService(BugChecker.class)
 @BugPattern(
         summary = "Gradle extensions should be registered using `create` rather than by constructing and passing a new "
-                + "instance to `add`. `create` ensures that Gradle manages the extension's lifecycle, type, "
-                + "and dependency injection correctly, while `add` with a manually constructed instance can "
-                + "lead to misconfigured extensions and bypasses Gradle's internal management.",
+                + "instance to `add`. Using `create` enables Gradle to properly manage the extension's type. "
+                + "Manual construction with `add` can interfere with certain error-prone checks.",
         severity = SeverityLevel.ERROR)
 public final class ExtensionsUseCreate extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
@@ -68,24 +69,25 @@ public final class ExtensionsUseCreate extends GradleGuideBugChecker implements 
         ExpressionTree instanceArg = args.get(args.size() - 1);
 
         if (instanceArg instanceof MethodInvocationTree methodArg) {
-            if (isIgnoredMethodInvocation(methodArg, state)) {
+            if (isIgnoredMethodInvocation(methodArg)) {
                 return Description.NO_MATCH;
             }
         }
 
         if (instanceArg instanceof NewClassTree newClass) {
-            return buildDescription(tree)
-                    .addFix(suggestCreateFix(tree, newClass, Optional.empty(), state)
-                            .build())
-                    .build();
+            Optional<SuggestedFixBuilder> maybeFix = suggestCreateFix(tree, newClass, Optional.empty(), state);
+            Description.Builder description = buildDescription(tree);
+            maybeFix.ifPresent(fix -> description.addFix(fix.build()));
+            return description.build();
         }
 
         if (instanceArg instanceof IdentifierTree ident) {
             Optional<VariableTree> varDecl = findVariableDeclaration(ident, state);
             if (varDecl.isPresent() && varDecl.get().getInitializer() instanceof NewClassTree newClass) {
-                return buildDescription(tree)
-                        .addFix(suggestCreateFix(tree, newClass, varDecl, state).build())
-                        .build();
+                Optional<SuggestedFixBuilder> maybeFix = suggestCreateFix(tree, newClass, varDecl, state);
+                Description.Builder description = buildDescription(tree);
+                maybeFix.ifPresent(fix -> description.addFix(fix.build()));
+                return description.build();
             }
         }
 
@@ -109,42 +111,54 @@ public final class ExtensionsUseCreate extends GradleGuideBugChecker implements 
                 .findFirst();
     }
 
-    private static SuggestedFixBuilder suggestCreateFix(
+    private static Optional<SuggestedFixBuilder> suggestCreateFix(
             MethodInvocationTree addCall,
             NewClassTree newClass,
             Optional<VariableTree> maybeVarDecl,
             VisitorState state) {
 
-        String extensionsReceiver = Optional.ofNullable(state.getSourceForNode(addCall.getMethodSelect()))
-                .orElse("/* project.getExtensions() */")
-                .replaceFirst("\\.add$", "");
+        String extensionsReceiver = state.getSourceForNode(addCall.getMethodSelect());
+        if (extensionsReceiver == null) {
+            return Optional.empty();
+        }
+        extensionsReceiver = extensionsReceiver.replaceFirst("\\.add$", "");
 
         Type extType = ASTHelpers.getType(newClass);
-        String extClass = extType == null ? "/* ExtensionType.class */" : extType.tsym.getSimpleName() + ".class";
+        if (extType == null) {
+            return Optional.empty();
+        }
+        String extClass = extType.tsym.getSimpleName() + ".class";
 
         List<? extends ExpressionTree> addArgs = addCall.getArguments();
         String extName = state.getSourceForNode(addArgs.get(addArgs.size() == 3 ? 1 : 0));
+        if (extName == null) {
+            return Optional.empty();
+        }
 
         String constructorArgs =
                 newClass.getArguments().stream().map(state::getSourceForNode).collect(Collectors.joining(", "));
 
         String createCall = Stream.of(extName, extClass, constructorArgs)
-                .filter(Objects::nonNull)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.joining(", ", extensionsReceiver + ".create(", ")"));
 
         SuggestedFixBuilder fix = new SuggestedFixBuilder();
         fix.replace(addCall, createCall);
         maybeVarDecl.ifPresent(fix::delete);
-        return fix;
+        return Optional.of(fix);
     }
 
-    private boolean isIgnoredMethodInvocation(MethodInvocationTree methodArg, VisitorState state) {
-        String calledName = state.getSourceForNode(methodArg.getMethodSelect());
-        return calledName == null
-                || calledName.endsWith(".getByName")
-                || calledName.endsWith(".findByName")
-                || calledName.endsWith(".findByType");
+    private boolean isIgnoredMethodInvocation(MethodInvocationTree methodArg) {
+        MethodSymbol methodSymbol = ASTHelpers.getSymbol(methodArg);
+        if (methodSymbol == null) {
+            return true;
+        }
+
+        Name methodName = methodSymbol.getSimpleName();
+        return methodName.contentEquals("getByName")
+                || methodName.contentEquals("findByName")
+                || methodName.contentEquals("findByType")
+                || methodName.contentEquals("getByType");
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreate.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreate.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.palantir.gradle.guide.errorprone;
 
 import com.google.auto.service.AutoService;
@@ -25,6 +24,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
+import com.palantir.gradle.guide.errorprone.utils.ReplacementTracker.SuggestedFixBuilder;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -34,13 +34,19 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import com.sun.tools.javac.code.Type;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @AutoService(BugChecker.class)
 @BugPattern(
-        summary =
-                "Gradle extensions should be registered using `create`, not by constructing and passing a new instance to `add`.",
+        summary = "Gradle extensions should be registered using `create` rather than by constructing and passing a new "
+                + "instance to `add`. `create` ensures that Gradle manages the extension's lifecycle, type, "
+                + "and dependency injection correctly, while `add` with a manually constructed instance can "
+                + "lead to misconfigured extensions and bypasses Gradle's internal management.",
         severity = SeverityLevel.ERROR)
 public final class ExtensionsUseCreate extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
@@ -58,22 +64,19 @@ public final class ExtensionsUseCreate extends GradleGuideBugChecker implements 
         if (args.size() != 2 && args.size() != 3) {
             return Description.NO_MATCH;
         }
+
         ExpressionTree instanceArg = args.get(args.size() - 1);
 
         if (instanceArg instanceof MethodInvocationTree methodArg) {
-            String calledName = state.getSourceForNode(methodArg.getMethodSelect());
-            if (calledName == null
-                    || calledName.endsWith(".getByName")
-                    || calledName.endsWith(".findByName")
-                    || calledName.endsWith(".findByType")) {
+            if (isIgnoredMethodInvocation(methodArg, state)) {
                 return Description.NO_MATCH;
             }
         }
 
         if (instanceArg instanceof NewClassTree newClass) {
             return buildDescription(tree)
-                    .setMessage(
-                            "Register extensions with `create`, not by constructing and passing a new instance to `add`.")
+                    .addFix(suggestCreateFix(tree, newClass, Optional.empty(), state)
+                            .build())
                     .build();
         }
 
@@ -81,8 +84,7 @@ public final class ExtensionsUseCreate extends GradleGuideBugChecker implements 
             Optional<VariableTree> varDecl = findVariableDeclaration(ident, state);
             if (varDecl.isPresent() && varDecl.get().getInitializer() instanceof NewClassTree newClass) {
                 return buildDescription(tree)
-                        .setMessage(
-                                "Register extensions with `create`, not by constructing and passing a new instance to `add`.")
+                        .addFix(suggestCreateFix(tree, newClass, varDecl, state).build())
                         .build();
             }
         }
@@ -95,21 +97,58 @@ public final class ExtensionsUseCreate extends GradleGuideBugChecker implements 
         if (!(sym instanceof VarSymbol varSym)) {
             return Optional.empty();
         }
-        // Walk up enclosing scope to find declaration using streams
-        for (TreePath path = state.getPath(); path != null; path = path.getParentPath()) {
-            if (path.getLeaf() instanceof BlockTree block) {
-                return block.getStatements().stream()
-                        .filter(stmt -> stmt instanceof VariableTree)
-                        .map(stmt -> (VariableTree) stmt)
-                        .filter(vt -> ASTHelpers.getSymbol(vt).equals(varSym))
-                        .findFirst();
-            }
-        }
-        return Optional.empty();
+        // Stream over the TreePath ancestry, filter for BlockTree, then stream their statements
+        return Stream.iterate(state.getPath(), Objects::nonNull, TreePath::getParentPath)
+                .map(TreePath::getLeaf)
+                .filter(BlockTree.class::isInstance)
+                .map(BlockTree.class::cast)
+                .flatMap(block -> block.getStatements().stream())
+                .filter(VariableTree.class::isInstance)
+                .map(VariableTree.class::cast)
+                .filter(vt -> ASTHelpers.getSymbol(vt).equals(varSym))
+                .findFirst();
+    }
+
+    private static SuggestedFixBuilder suggestCreateFix(
+            MethodInvocationTree addCall,
+            NewClassTree newClass,
+            Optional<VariableTree> maybeVarDecl,
+            VisitorState state) {
+
+        String extensionsReceiver = Optional.ofNullable(state.getSourceForNode(addCall.getMethodSelect()))
+                .orElse("/* project.getExtensions() */")
+                .replaceFirst("\\.add$", "");
+
+        Type extType = ASTHelpers.getType(newClass);
+        String extClass = extType == null ? "/* ExtensionType.class */" : extType.tsym.getSimpleName() + ".class";
+
+        List<? extends ExpressionTree> addArgs = addCall.getArguments();
+        String extName = state.getSourceForNode(addArgs.get(addArgs.size() == 3 ? 1 : 0));
+
+        String constructorArgs =
+                newClass.getArguments().stream().map(state::getSourceForNode).collect(Collectors.joining(", "));
+
+        String createCall = Stream.of(extName, extClass, constructorArgs)
+                .filter(Objects::nonNull)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(", ", extensionsReceiver + ".create(", ")"));
+
+        SuggestedFixBuilder fix = new SuggestedFixBuilder();
+        fix.replace(addCall, createCall);
+        maybeVarDecl.ifPresent(fix::delete);
+        return fix;
+    }
+
+    private boolean isIgnoredMethodInvocation(MethodInvocationTree methodArg, VisitorState state) {
+        String calledName = state.getSourceForNode(methodArg.getMethodSelect());
+        return calledName == null
+                || calledName.endsWith(".getByName")
+                || calledName.endsWith(".findByName")
+                || calledName.endsWith(".findByType");
     }
 
     @Override
     public MoreInfoLink moreInfoLink() {
-        return new MoreInfoPageLink("extensions-use-create.md");
+        return new MoreInfoPageLink("managed-types-and-properties.md");
     }
 }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreate.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreate.java
@@ -1,0 +1,115 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
+import java.util.List;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        summary =
+                "Gradle extensions should be registered using `create`, not by constructing and passing a new instance to `add`.",
+        severity = SeverityLevel.ERROR)
+public final class ExtensionsUseCreate extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> IS_EXTENSION_ADD = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.plugins.ExtensionContainer")
+            .named("add");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!IS_EXTENSION_ADD.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        List<? extends ExpressionTree> args = tree.getArguments();
+        if (args.size() != 2 && args.size() != 3) {
+            return Description.NO_MATCH;
+        }
+        ExpressionTree instanceArg = args.get(args.size() - 1);
+
+        if (instanceArg instanceof MethodInvocationTree methodArg) {
+            String calledName = state.getSourceForNode(methodArg.getMethodSelect());
+            if (calledName == null
+                    || calledName.endsWith(".getByName")
+                    || calledName.endsWith(".findByName")
+                    || calledName.endsWith(".findByType")) {
+                return Description.NO_MATCH;
+            }
+        }
+
+        if (instanceArg instanceof NewClassTree newClass) {
+            return buildDescription(tree)
+                    .setMessage(
+                            "Register extensions with `create`, not by constructing and passing a new instance to `add`.")
+                    .build();
+        }
+
+        if (instanceArg instanceof IdentifierTree ident) {
+            Optional<VariableTree> varDecl = findVariableDeclaration(ident, state);
+            if (varDecl.isPresent() && varDecl.get().getInitializer() instanceof NewClassTree newClass) {
+                return buildDescription(tree)
+                        .setMessage(
+                                "Register extensions with `create`, not by constructing and passing a new instance to `add`.")
+                        .build();
+            }
+        }
+
+        return Description.NO_MATCH;
+    }
+
+    private static Optional<VariableTree> findVariableDeclaration(IdentifierTree ident, VisitorState state) {
+        Symbol sym = ASTHelpers.getSymbol(ident);
+        if (!(sym instanceof VarSymbol varSym)) {
+            return Optional.empty();
+        }
+        // Walk up enclosing scope to find declaration using streams
+        for (TreePath path = state.getPath(); path != null; path = path.getParentPath()) {
+            if (path.getLeaf() instanceof BlockTree block) {
+                return block.getStatements().stream()
+                        .filter(stmt -> stmt instanceof VariableTree)
+                        .map(stmt -> (VariableTree) stmt)
+                        .filter(vt -> ASTHelpers.getSymbol(vt).equals(varSym))
+                        .findFirst();
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public MoreInfoLink moreInfoLink() {
+        return new MoreInfoPageLink("extensions-use-create.md");
+    }
+}

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
@@ -1,0 +1,120 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+public class ExtensionsUseCreateTest {
+    private final CompilationTestHelper compilationTestHelper =
+            CompilationTestHelper.newInstance(ExtensionsUseCreate.class, getClass());
+
+    @Test
+    void flags_direct_new_instance_passed_to_add() {
+        test(
+                """
+                import org.gradle.api.Project;
+                class FooExtension { FooExtension(String a, String b) {} }
+                class Test {
+                    void foo(Project project) {
+                        // BUG: Diagnostic contains: Register extensions with `create`
+                        project.getExtensions().add("foo", new FooExtension("a", "b"));
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void flags_variable_with_new_instance_passed_to_add() {
+        test(
+                """
+                import org.gradle.api.Project;
+                class FooExtension { FooExtension(String a, String b) {} }
+                class Test {
+                    void foo(Project project) {
+                        FooExtension ext = new FooExtension("a", "b");
+                        // BUG: Diagnostic contains: Register extensions with `create`
+                        project.getExtensions().add("foo", ext);
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void allows_variable_with_method_call_passed_to_add() {
+        test(
+                """
+                import org.gradle.api.Project;
+                class FooExtension {}
+                class Test {
+                    static FooExtension loadExt() { return new FooExtension(); }
+                    void foo(Project project) {
+                        FooExtension ext = loadExt();
+                        project.getExtensions().add("foo", ext);
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void allows_direct_method_call_passed_to_add() {
+        test(
+                """
+                import org.gradle.api.Project;
+                class FooExtension {}
+                class Test {
+                    static FooExtension loadExt() { return new FooExtension(); }
+                    void foo(Project project) {
+                        project.getExtensions().add("foo", loadExt());
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void allows_getByName() {
+        test(
+                """
+                import org.gradle.api.Project;
+                class Test {
+                    void foo(Project project) {
+                        project.getExtensions().add("foo", project.getRootProject().getExtensions().getByName("foo"));
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void allows_findByType() {
+        test(
+                """
+                import org.gradle.api.Project;
+                class FooExtension {}
+                class Test {
+                    void foo(Project project) {
+                        FooExtension ext = project.getExtensions().findByType(FooExtension.class);
+                        project.getExtensions().add("foo", ext);
+                    }
+                }
+                """);
+    }
+
+    private void test(@Language("Java") String source) {
+        compilationTestHelper.addSourceLines("Test.java", source).doTest();
+    }
+}

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
@@ -15,6 +15,7 @@
  */
 package com.palantir.gradle.guide.errorprone;
 
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import com.palantir.gradle.guide.helpers.RefactoringValidator;
 import org.intellij.lang.annotations.Language;
@@ -359,14 +360,20 @@ class ExtensionsUseCreateTest {
         }
 
         private void refactoringTest(@Language("Java") String input, @Language("Java") String expected) {
-            bestEffortRefactoringValidator()
+            BugCheckerRefactoringTestHelper refactoringTestHelper =
+                    BugCheckerRefactoringTestHelper.newInstance(ExtensionsUseCreate.class, getClass());
+
+            refactoringTestHelper
                     .addInputLines("Test.java", input)
                     .addOutputLines("Test.java", expected)
                     .doTest();
         }
 
         private void refactoringNoop(@Language("Java") String code) {
-            bestEffortRefactoringValidator()
+            BugCheckerRefactoringTestHelper refactoringTestHelper =
+                    BugCheckerRefactoringTestHelper.newInstance(ExtensionsUseCreate.class, getClass());
+
+            refactoringTestHelper
                     .addInputLines("Test.java", code)
                     .expectUnchanged()
                     .doTest();

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
@@ -13,108 +13,363 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.palantir.gradle.guide.errorprone;
 
 import com.google.errorprone.CompilationTestHelper;
+import com.palantir.gradle.guide.helpers.RefactoringValidator;
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public class ExtensionsUseCreateTest {
+class ExtensionsUseCreateTest {
     private final CompilationTestHelper compilationTestHelper =
             CompilationTestHelper.newInstance(ExtensionsUseCreate.class, getClass());
 
-    @Test
-    void flags_direct_new_instance_passed_to_add() {
-        test(
-                """
-                import org.gradle.api.Project;
-                class FooExtension { FooExtension(String a, String b) {} }
-                class Test {
-                    void foo(Project project) {
-                        // BUG: Diagnostic contains: Register extensions with `create`
-                        project.getExtensions().add("foo", new FooExtension("a", "b"));
-                    }
-                }
-                """);
+    private RefactoringValidator bestEffortRefactoringValidator() {
+        return refactoringValidator("-XepOpt:GradleGuide:BestEffortMode");
     }
 
-    @Test
-    void flags_variable_with_new_instance_passed_to_add() {
-        test(
-                """
-                import org.gradle.api.Project;
-                class FooExtension { FooExtension(String a, String b) {} }
-                class Test {
-                    void foo(Project project) {
-                        FooExtension ext = new FooExtension("a", "b");
-                        // BUG: Diagnostic contains: Register extensions with `create`
-                        project.getExtensions().add("foo", ext);
-                    }
-                }
-                """);
+    private RefactoringValidator refactoringValidator(String... args) {
+        return RefactoringValidator.of(ExtensionsUseCreate.class, getClass(), args);
     }
 
-    @Test
-    void allows_variable_with_method_call_passed_to_add() {
-        test(
-                """
-                import org.gradle.api.Project;
-                class FooExtension {}
-                class Test {
-                    static FooExtension loadExt() { return new FooExtension(); }
-                    void foo(Project project) {
-                        FooExtension ext = loadExt();
-                        project.getExtensions().add("foo", ext);
+    @Nested
+    class Diagnostics {
+        @Test
+        void flags_direct_new_instance_passed_to_add() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension { FooExtension(String a, String b) {} }
+                    class Test {
+                        void foo(Project project) {
+                            // BUG: Diagnostic contains: registered using `create`
+                            project.getExtensions().add("foo", new FooExtension("a", "b"));
+                        }
                     }
-                }
-                """);
+                    """);
+        }
+
+        @Test
+        void flags_variable_with_new_instance_passed_to_add() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension { FooExtension(String a, String b) {} }
+                    class Test {
+                        void foo(Project project) {
+                            FooExtension ext = new FooExtension("a", "b");
+                            // BUG: Diagnostic contains: registered using `create`
+                            project.getExtensions().add("foo", ext);
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void flags_direct_new_instance_passed_to_add_with_public_type() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension { FooExtension(String a, String b) {} }
+                    class Test {
+                        void foo(Project project) {
+                            // BUG: Diagnostic contains: registered using `create`
+                            project.getExtensions().add(FooExtension.class, "foo", new FooExtension("a", "b"));
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void flags_variable_new_instance_passed_to_add_with_public_type() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension { FooExtension(String a, String b) {} }
+                    class Test {
+                        void foo(Project project) {
+                            FooExtension ext = new FooExtension("a", "b");
+                            // BUG: Diagnostic contains: registered using `create`
+                            project.getExtensions().add(FooExtension.class, "foo", ext);
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void allows_variable_with_method_call_passed_to_add() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension {}
+                    class Test {
+                        static FooExtension loadExt() { return new FooExtension(); }
+                        void foo(Project project) {
+                            FooExtension ext = loadExt();
+                            project.getExtensions().add("foo", ext);
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void allows_direct_method_call_passed_to_add() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension {}
+                    class Test {
+                        static FooExtension loadExt() { return new FooExtension(); }
+                        void foo(Project project) {
+                            project.getExtensions().add("foo", loadExt());
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void allows_variable_with_method_call_passed_to_add_with_public_type() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension {}
+                    class Test {
+                        static FooExtension loadExt() { return new FooExtension(); }
+                        void foo(Project project) {
+                            FooExtension ext = loadExt();
+                            project.getExtensions().add(FooExtension.class, "foo", ext);
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void allows_getByName() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            project.getExtensions().add("foo", project.getRootProject().getExtensions()
+                                                                                                    .getByName("foo"));
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void allows_findByType() {
+            test(
+                    """
+                    import org.gradle.api.Project;
+                    class FooExtension {}
+                    class Test {
+                        void foo(Project project) {
+                            FooExtension ext = project.getExtensions().findByType(FooExtension.class);
+                            project.getExtensions().add("foo", ext);
+                        }
+                    }
+                    """);
+        }
+
+        private void test(@Language("Java") String source) {
+            compilationTestHelper.addSourceLines("Test.java", source).doTest();
+        }
     }
 
-    @Test
-    void allows_direct_method_call_passed_to_add() {
-        test(
-                """
-                import org.gradle.api.Project;
-                class FooExtension {}
-                class Test {
-                    static FooExtension loadExt() { return new FooExtension(); }
-                    void foo(Project project) {
-                        project.getExtensions().add("foo", loadExt());
-                    }
-                }
-                """);
-    }
+    @Nested
+    class Refactoring {
+        @Test
+        void replaces_direct_new_instance_passed_to_add() {
+            refactoringTest(
+                    """
+                            import org.gradle.api.Project;
+                            class Test {
+                                void foo(Project project) {
+                                    project.getExtensions().add("foo", new FooExtension("a", "b"));
+                                }
 
-    @Test
-    void allows_getByName() {
-        test(
-                """
-                import org.gradle.api.Project;
-                class Test {
-                    void foo(Project project) {
-                        project.getExtensions().add("foo", project.getRootProject().getExtensions().getByName("foo"));
-                    }
-                }
-                """);
-    }
+                                class FooExtension { FooExtension(String a, String b) {} }
+                            }
+                            """,
+                    """
+                            import org.gradle.api.Project;
+                            class Test {
+                                void foo(Project project) {
+                                    project.getExtensions().create("foo", FooExtension.class, "a", "b");
+                                }
 
-    @Test
-    void allows_findByType() {
-        test(
-                """
-                import org.gradle.api.Project;
-                class FooExtension {}
-                class Test {
-                    void foo(Project project) {
-                        FooExtension ext = project.getExtensions().findByType(FooExtension.class);
-                        project.getExtensions().add("foo", ext);
-                    }
-                }
-                """);
-    }
+                                class FooExtension { FooExtension(String a, String b) {} }
+                            }
+                            """);
+        }
 
-    private void test(@Language("Java") String source) {
-        compilationTestHelper.addSourceLines("Test.java", source).doTest();
+        @Test
+        void replaces_variable_with_new_instance_passed_to_add() {
+            refactoringTest(
+                    """
+                            import org.gradle.api.Project;
+                            class Test {
+                                void foo(Project project) {
+                                    FooExtension ext = new FooExtension("a", "b");
+                                    project.getExtensions().add("foo", ext);
+                                }
+
+                                class FooExtension { FooExtension(String a, String b) {} }
+                            }
+                            """,
+                    """
+                            import org.gradle.api.Project;
+                            class Test {
+                                void foo(Project project) {
+                                    project.getExtensions().create("foo", FooExtension.class, "a", "b");
+                                }
+
+                                class FooExtension { FooExtension(String a, String b) {} }
+                            }
+                            """);
+        }
+
+        @Test
+        void replaces_direct_new_instance_passed_to_add_with_public_type() {
+            refactoringTest(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            project.getExtensions().add(FooExtension.class, "foo", new FooExtension("a", "b"));
+                        }
+                        class FooExtension { FooExtension(String a, String b) {} }
+                    }
+                    """,
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            project.getExtensions().create("foo", FooExtension.class, "a", "b");
+                        }
+                        class FooExtension { FooExtension(String a, String b) {} }
+                    }
+                    """);
+        }
+
+        @Test
+        void replaces_variable_new_instance_passed_to_add_with_public_type() {
+            refactoringTest(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            FooExtension ext = new FooExtension("a", "b");
+                            project.getExtensions().add(FooExtension.class, "foo", ext);
+                        }
+                        class FooExtension { FooExtension(String a, String b) {} }
+                    }
+                    """,
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            project.getExtensions().create("foo", FooExtension.class, "a", "b");
+                        }
+                        class FooExtension { FooExtension(String a, String b) {} }
+                    }
+                    """);
+        }
+
+        @Test
+        void does_not_change_variable_with_method_call() {
+            refactoringNoop(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        static FooExtension loadExt() { return new FooExtension(); }
+                        void foo(Project project) {
+                            FooExtension ext = loadExt();
+                            project.getExtensions().add("foo", ext);
+                        }
+
+                        static class FooExtension {}
+                    }
+                    """);
+        }
+
+        @Test
+        void does_not_change_direct_method_call() {
+            refactoringNoop(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        static FooExtension loadExt() { return new FooExtension(); }
+                        void foo(Project project) {
+                            project.getExtensions().add("foo", loadExt());
+                        }
+
+                        static class FooExtension {}
+                    }
+                    """);
+        }
+
+        @Test
+        void does_not_change_variable_with_method_call_passed_to_add_with_public_type() {
+            refactoringNoop(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        static FooExtension loadExt() { return new FooExtension(); }
+                        void foo(Project project) {
+                            FooExtension ext = loadExt();
+                            project.getExtensions().add(FooExtension.class, "foo", ext);
+                        }
+
+                        static class FooExtension {}
+                    }
+                    """);
+        }
+
+        @Test
+        void does_not_change_getByName() {
+            refactoringNoop(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            project.getExtensions().add("foo", project.getRootProject().getExtensions()
+                                                                                                    .getByName("foo"));
+                        }
+                    }
+                    """);
+        }
+
+        @Test
+        void does_not_change_findByType() {
+            refactoringNoop(
+                    """
+                    import org.gradle.api.Project;
+                    class Test {
+                        void foo(Project project) {
+                            FooExtension ext = project.getExtensions().findByType(FooExtension.class);
+                            project.getExtensions().add("foo", ext);
+                        }
+
+                        class FooExtension {}
+                    }
+                    """);
+        }
+
+        private void refactoringTest(@Language("Java") String input, @Language("Java") String expected) {
+            bestEffortRefactoringValidator()
+                    .addInputLines("Test.java", input)
+                    .addOutputLines("Test.java", expected)
+                    .doTest();
+        }
+
+        private void refactoringNoop(@Language("Java") String code) {
+            bestEffortRefactoringValidator()
+                    .addInputLines("Test.java", code)
+                    .expectUnchanged()
+                    .doTest();
+        }
     }
 }

--- a/guide/managed-types-and-properties.md
+++ b/guide/managed-types-and-properties.md
@@ -60,6 +60,25 @@ This is very similar to [the commonly used `immutables` library](https://immutab
 
 It is possible to write extensions and tasks directly as in the `HelloExtension_Generated` class above. If you look into the depths of older Palantir Gradle code you will find many instances of this, but this is no longer recommended. All new code should use Managed Types.
 
+### Why prefer `create` over `add` for extensions?
+
+Always register an extension via
+
+```java
+project.getExtensions().create("name", MyExtension.class);
+```
+rather than
+
+```java
+project.getExtensions().add("name", new MyExtension(/* … */));
+```
+create asks Gradle to
+- build a managed instance (using Gradle’s code-generation),
+- wire that instance into Gradle’s lifecycle and dependency-injection system
+- keep all properties lazily realizable so they can still be configured after creation but before task-graph realisation. 
+
+Passing a manually constructed new MyExtension(…) to add skips all of this—the object is unmanaged, Gradle cannot inject services, and property realisation becomes eager, often leading to brittle or misconfigured builds.
+
 ## Tasks
 
 Similarly, for tasks, they should look like below rather than being manually specified:

--- a/guide/managed-types-and-properties.md
+++ b/guide/managed-types-and-properties.md
@@ -62,7 +62,7 @@ It is possible to write extensions and tasks directly as in the `HelloExtension_
 
 ### Why prefer `create` over `add` for extensions?
 
-Always register an extension via
+Prefer register an extension via
 
 ```java
 project.getExtensions().create("name", MyExtension.class);
@@ -75,9 +75,8 @@ project.getExtensions().add("name", new MyExtension(/* … */));
 create asks Gradle to
 - build a managed instance (using Gradle’s code-generation),
 - wire that instance into Gradle’s lifecycle and dependency-injection system
-- keep all properties lazily realizable so they can still be configured after creation but before task-graph realisation. 
 
-Passing a manually constructed new MyExtension(…) to add skips all of this—the object is unmanaged, Gradle cannot inject services, and property realisation becomes eager, often leading to brittle or misconfigured builds.
+This is mostly stylistic but is important as our Errorprones are built to detect extensions instantiated via `create`
 
 ## Tasks
 


### PR DESCRIPTION
## Before this PR
had no errorprone to prevent behaviour like:

```java
project.getExtensions().add("foo", new fooExtension());
```

## After this PR
We now have an errorprone with autofix to prevent users from doing this it will auto fix as below:

```java
project.getExtensions().add("foo", new FooExtension("a", "b"));
```
-->
```java
project.getExtensions().create("foo", FooExtension.class, "a", "b");
```

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure that extensions are only added via `.create`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

