### PR TITLE
Fix false positives of `IllegalMethodCalledDuringTaskExecution` when `getProject()` is called both inside and outside of the execution phase

### DIFF
--- a/gradle-guide-error-prone/build.gradle
+++ b/gradle-guide-error-prone/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.palantir.external-publish-jar'
 dependencies {
     api 'com.google.errorprone:error_prone_check_api'
 
+    implementation 'one.util:streamex'
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service'
 

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecution.java
@@ -85,13 +85,18 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
         }
 
         MethodSymbol enclosingMethod = ASTHelpers.getSymbol(enclosingMethodMaybe.get());
-        Set<MethodSymbol> transitiveCallers = callGraph.transitiveCallers(enclosingMethod);
-        transitiveCallers.add(enclosingMethod);
+        // Find transitive callers of enclosing method first, as the illegal method e.g. getProject() is defined in
+        // Gradle source, not the source file this BugChecker is running on.
+        // If we included methods defined externally into the call graph,
+        // IllegalMethodCalledDuringTaskExecutionTest#getProject_in_constructor_ok will fail.
+        Set<MethodSymbol> transitiveCallersOfIllegalMethod = callGraph.transitiveCallers(enclosingMethod);
+        transitiveCallersOfIllegalMethod.add(enclosingMethod);
 
-        boolean isInvokedAtTaskExecution = transitiveCallers.stream().anyMatch(caller -> {
-            MethodTree callerTree = ASTHelpers.findMethod(caller, state);
-            return isTaskAction(callerTree, state) || overridesExecute(callerTree, state);
-        });
+        boolean isInvokedAtTaskExecution = transitiveCallersOfIllegalMethod.stream()
+                .anyMatch(caller -> {
+                    MethodTree callerTree = ASTHelpers.findMethod(caller, state);
+                    return isTaskAction(callerTree, state) || overridesExecute(callerTree, state);
+                });
         if (isInvokedAtTaskExecution) {
             firstMatchingViolation.get().fixOrReport(tree, state);
         }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecution.java
@@ -40,6 +40,7 @@ import com.sun.tools.javac.code.Type.ClassType;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import one.util.streamex.StreamEx;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -90,9 +91,9 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
         // If we included methods defined externally into the call graph,
         // IllegalMethodCalledDuringTaskExecutionTest#getProject_in_constructor_ok will fail.
         Set<MethodSymbol> transitiveCallersOfIllegalMethod = callGraph.transitiveCallers(enclosingMethod);
-        transitiveCallersOfIllegalMethod.add(enclosingMethod);
 
-        boolean isInvokedAtTaskExecution = transitiveCallersOfIllegalMethod.stream()
+        boolean isInvokedAtTaskExecution = StreamEx.of(transitiveCallersOfIllegalMethod)
+                .append(enclosingMethod)
                 .anyMatch(caller -> {
                     MethodTree callerTree = ASTHelpers.findMethod(caller, state);
                     return isTaskAction(callerTree, state) || overridesExecute(callerTree, state);

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecution.java
@@ -78,8 +78,15 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
 
         CompilationUnitTree compilationUnit = state.getPath().getCompilationUnit();
         MethodCallGraph callGraph = MethodCallGraph.getOrBuild(compilationUnit);
-        MethodSymbol matched = ASTHelpers.getSymbol(tree);
-        Set<MethodSymbol> transitiveCallers = callGraph.transitiveCallers(matched);
+
+        Optional<MethodTree> enclosingMethodMaybe = Optional.ofNullable(ASTHelpers.findEnclosingMethod(state));
+        if (enclosingMethodMaybe.isEmpty()) {
+            return Description.NO_MATCH;
+        }
+
+        MethodSymbol enclosingMethod = ASTHelpers.getSymbol(enclosingMethodMaybe.get());
+        Set<MethodSymbol> transitiveCallers = callGraph.transitiveCallers(enclosingMethod);
+        transitiveCallers.add(enclosingMethod);
 
         boolean isInvokedAtTaskExecution = transitiveCallers.stream().anyMatch(caller -> {
             MethodTree callerTree = ASTHelpers.findMethod(caller, state);

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/MethodCallGraph.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/MethodCallGraph.java
@@ -57,14 +57,14 @@ public final class MethodCallGraph {
         MutableGraph<MethodSymbol> mutableCallGraph =
                 GraphBuilder.directed().allowsSelfLoops(true).build();
 
-        new TreePathScanner<Void, Optional<MethodSymbol>>() {
+        new TreePathScanner<Void, Void>() {
             @Override
-            public Void visitMethod(MethodTree node, Optional<MethodSymbol> caller) {
+            public Void visitMethod(MethodTree node, Void unused) {
                 MethodSymbol methodSymbol = ASTHelpers.getSymbol(node);
                 mutableCallGraph.addNode(methodSymbol);
-                return super.visitMethod(node, Optional.of(methodSymbol));
+                return super.visitMethod(node, unused);
             }
-        }.scan(compilationUnitTree, Optional.empty());
+        }.scan(compilationUnitTree, null);
 
         new TreePathScanner<Void, Optional<MethodSymbol>>() {
             @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/MethodCallGraph.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/MethodCallGraph.java
@@ -48,8 +48,8 @@ public final class MethodCallGraph {
     }
 
     /**
-     * Nodes are {@code MethodSymbol}s. There is an edge from {@code f} to {@code g} iff {@code f} is called by
-     * {@code g}.
+     * Nodes are {@code MethodSymbol}s of methods declared within this compilation unit.
+     * There is an edge from {@code f} to {@code g} iff {@code f} is called by {@code g}.
      */
     private final ImmutableGraph<MethodSymbol> callGraph;
 

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/MethodCallGraph.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/utils/MethodCallGraph.java
@@ -64,17 +64,22 @@ public final class MethodCallGraph {
                 mutableCallGraph.addNode(methodSymbol);
                 return super.visitMethod(node, Optional.of(methodSymbol));
             }
+        }.scan(compilationUnitTree, Optional.empty());
+
+        new TreePathScanner<Void, Optional<MethodSymbol>>() {
+            @Override
+            public Void visitMethod(MethodTree node, Optional<MethodSymbol> caller) {
+                MethodSymbol methodSymbol = ASTHelpers.getSymbol(node);
+                return super.visitMethod(node, Optional.of(methodSymbol));
+            }
 
             @Override
             public Void visitMethodInvocation(MethodInvocationTree node, Optional<MethodSymbol> caller) {
                 MethodSymbol calleeSymbol = (MethodSymbol) ASTHelpers.getSymbol(node.getMethodSelect());
-                mutableCallGraph.addNode(calleeSymbol);
-
-                if (caller.isPresent()) {
+                if (mutableCallGraph.nodes().contains(calleeSymbol) && caller.isPresent()) {
                     MethodSymbol callerSymbol = caller.get();
                     mutableCallGraph.putEdge(calleeSymbol, callerSymbol);
                 }
-
                 return super.visitMethodInvocation(node, caller);
             }
         }.scan(compilationUnitTree, Optional.empty());

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecutionTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecutionTest.java
@@ -305,6 +305,30 @@ class IllegalMethodCalledDuringTaskExecutionTest {
                 }
             """);
         }
+
+        @Test
+        void getProject_in_constructor_ok() {
+            test(
+                    """
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.tasks.TaskAction;
+
+                abstract class CustomTask extends DefaultTask {
+                    CustomTask() {
+                        // Illegal method in task constructor (configuration phase) is OK
+                        Project project = getProject();
+                    }
+
+                    @TaskAction
+                    final void action() {
+                        @SuppressWarnings("IllegalMethodCalledDuringTaskExecution")
+                        Project project = getProject();
+                    }
+                }
+            """);
+        }
     }
 
     /**
@@ -429,6 +453,7 @@ class IllegalMethodCalledDuringTaskExecutionTest {
                             });
                         });
 
+                        // TODO(okelvin): fix lambdas
                         project.getTasks().withType(Task.class, tsk -> tsk.doLast(
                             (Action<Task>) task -> task.getProject().getLogger().info("I am a happy squirrel")));
                     }
@@ -455,8 +480,9 @@ class IllegalMethodCalledDuringTaskExecutionTest {
                             });
                         });
 
+                        // TODO(okelvin): fix lambdas
                         project.getTasks().withType(Task.class, tsk -> tsk.doLast(
-                            (Action<Task>) task -> task.getLogger().info("I am a happy squirrel")));
+                            (Action<Task>) task -> task.getProject().getLogger().info("I am a happy squirrel")));
                     }
                 }
             """);

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecutionTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecutionTest.java
@@ -317,7 +317,8 @@ class IllegalMethodCalledDuringTaskExecutionTest {
 
                 abstract class CustomTask extends DefaultTask {
                     CustomTask() {
-                        // Illegal method in task constructor (configuration phase) is OK
+                        // getProject() in task constructor is OK,
+                        // even when getProject() is illegally called elsewhere.
                         Project project = getProject();
                     }
 

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecutionTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/IllegalMethodCalledDuringTaskExecutionTest.java
@@ -307,7 +307,7 @@ class IllegalMethodCalledDuringTaskExecutionTest {
         }
 
         @Test
-        void getProject_in_constructor_ok() {
+        void getProject_in_TaskAction_doesnt_cause_other_getProjects_to_be_flagged() {
             test(
                     """
                 import org.gradle.api.DefaultTask;
@@ -316,14 +316,17 @@ class IllegalMethodCalledDuringTaskExecutionTest {
                 import org.gradle.api.tasks.TaskAction;
 
                 abstract class CustomTask extends DefaultTask {
+                    // getProject() in field is OK
+                    private final Project project = getProject();
+
                     CustomTask() {
-                        // getProject() in task constructor is OK,
-                        // even when getProject() is illegally called elsewhere.
+                        // getProject() in task constructor is OK
                         Project project = getProject();
                     }
 
                     @TaskAction
                     final void action() {
+                        // ... even if getProject()
                         @SuppressWarnings("IllegalMethodCalledDuringTaskExecution")
                         Project project = getProject();
                     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

`IllegalMethodCalledDuringTaskExecution` incorrectly flags `getProject()` calls outside the execution phase when the same method is also called inside a `@TaskAction`:

```java
abstract class CustomTask extends DefaultTask {
    CustomTask() {
        Project project = getProject();
    }

    @TaskAction
    final void action() {
        Project project = getProject();
    }
}
```


**Root cause:** The call graph included external methods (like `getProject()`) as nodes. When analyzing the constructor's `getProject()` call, the checker found `action()` in the transitive callers of `getProject()` and incorrectly assumed the constructor call was execution-phase related.


## After this PR
<!-- User-facing outcomes this PR delivers go below -->

**Call graph change:** Only have nodes for methods defined in the current source file (excludes external methods like `getProject()`)

**Bug checker change**: Query transitive callers of the enclosing method (constructor) instead of the external method

This correctly identifies whether a call occurs within the transitive closure of a `@TaskAction`.


==COMMIT_MSG==
Fix false positives of `IllegalMethodCalledDuringTaskExecution` when `getProject()` is called both inside and outside of the execution phase
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

