### PR TITLE
Mention that we ship the NonAbstractGradleType errorprone in "Managed Types"

### DIFF
--- a/guide/managed-types-and-properties.md
+++ b/guide/managed-types-and-properties.md
@@ -80,9 +80,7 @@ public abstract class SomeTask extends DefaultTask {
 ```
 
 > [!NOTE]
-> This repository ships with the [NonAbstractGradleType](https://github.com/palantir/gradle-guide/blob/develop/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java) errorprone, which automatically fixes your Gradle tasks to be abstract.  
-
-
+> This repository ships with the [NonAbstractGradleType](https://github.com/palantir/gradle-guide/blob/develop/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java) errorprone, which automatically fixes your Gradle tasks to be abstract.
 
 <!-- PreviousNext:START -->
 <hr>

--- a/guide/managed-types-and-properties.md
+++ b/guide/managed-types-and-properties.md
@@ -79,6 +79,11 @@ public abstract class SomeTask extends DefaultTask {
 } 
 ```
 
+> [!NOTE]
+> This repository ships with the [NonAbstractGradleType](https://github.com/palantir/gradle-guide/blob/develop/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/NonAbstractGradleType.java) errorprone, which automatically fixes your Gradle tasks to be abstract.  
+
+
+
 <!-- PreviousNext:START -->
 <hr>
 <table><tr>


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Let's mention that we ship this errorprone in the gradle guide

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Mention that we ship the `NonAbstractGradleType` errorprone in "Managed Types"
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

