### PR TITLE
Autofix `getProject().copy()` to `getFileSystemOperations().copy()`

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -69,6 +69,10 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .onDescendantOf("org.gradle.api.Project")
             .named("getProjectDir")
             .withNoParameters();
+    private static final Matcher<ExpressionTree> copy = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("copy")
+            .withParameters("org.gradle.api.Action");
 
     private static final TaskExecutionViolation REPORT_GET_PROJECT = TaskExecutionViolation.report(
             ChainedCallMatcher.of(getProject), "Don't call `getProject()` in task actions");
@@ -83,9 +87,17 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             GradleFix.of(
                     GradleService.PROJECT_LAYOUT,
                     Replacement.literal("getProjectLayout().getProjectDirectory().getAsFile()")));
+    private static final TaskExecutionViolation FIX_GET_PROJECT_COPY = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, copy),
+            "Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`",
+            GradleFix.of(
+                    GradleService.FILE_SYSTEMS_OPERATIONS, Replacement.template("getFileSystemOperations().copy(%s)")));
 
     private static final List<TaskExecutionViolation> violationsInOrderOfSpecificity = Stream.of(
-                    FIX_GET_PROJECT_GET_PROJECT_DIR, FIX_GET_PROJECT_GET_LOGGER, REPORT_GET_PROJECT)
+                    FIX_GET_PROJECT_COPY,
+                    FIX_GET_PROJECT_GET_PROJECT_DIR,
+                    FIX_GET_PROJECT_GET_LOGGER,
+                    REPORT_GET_PROJECT)
             .sorted()
             .toList();
 

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/GetProjectCopyTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/GetProjectCopyTest.java
@@ -1,0 +1,176 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.taskexecution;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("LineLength")
+public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTest {
+    @Test
+    void projectLayout_not_injected_should_fix_and_inject() {
+        testFix(
+                "AlreadyAbstractTask.java",
+                """
+                import java.io.File;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyAbstractTask extends DefaultTask {
+                    @TaskAction
+                    final void action() {
+                        getProject().copy(copySpec -> {
+                            copySpec.from("src");
+                            copySpec.into("dest");
+                        });
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.FileSystemOperations;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyAbstractTask extends DefaultTask {
+                    @Inject
+                    protected abstract FileSystemOperations getFileSystemOperations();
+                    @TaskAction
+                    final void action() {
+                        getFileSystemOperations().copy(copySpec -> {
+                            copySpec.from("src");
+                            copySpec.into("dest");
+                        });
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void fileSystemOperations_already_injected_should_fix_without_injecting_again() {
+        testFix(
+                "AlreadyInjectedTask.java",
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.FileSystemOperations;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    @Inject
+                    protected abstract FileSystemOperations getFileSystemOperations();
+                    @TaskAction
+                    final void action() {
+                        getFileSystemOperations().delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getProject().copy(copySpec -> {
+                            copySpec.from("src");
+                        });
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.FileSystemOperations;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    @Inject
+                    protected abstract FileSystemOperations getFileSystemOperations();
+                    @TaskAction
+                    final void action() {
+                        getFileSystemOperations().delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getFileSystemOperations().copy(copySpec -> {
+                            copySpec.from("src");
+                        });
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void concrete_task_should_fix() {
+        testFix(
+                "ConcreteTask.java",
+                """
+                import java.io.File;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.tasks.TaskAction;
+                class ConcreteTask extends DefaultTask {
+                    @TaskAction
+                    final void action() {
+                        getProject().copy(copySpec -> {
+                            copySpec.from("input");
+                            copySpec.into("output");
+                        });
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.FileSystemOperations;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class ConcreteTask extends DefaultTask {
+                    @Inject
+                    protected abstract FileSystemOperations getFileSystemOperations();
+                    @TaskAction
+                    final void action() {
+                        getFileSystemOperations().copy(copySpec -> {
+                            copySpec.from("input");
+                            copySpec.into("output");
+                        });
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void transitive_calls_to_getProject_copy_should_fail_in_taskActions() {
+        test(
+                """
+                import org.gradle.api.Action;
+                import org.gradle.api.Task;
+                abstract class CustomTaskAction implements Action<Task> {
+                    @Override
+                    public void execute(Task task) {
+                        // BUG: Diagnostic contains: Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`
+                        task.getProject().copy(copySpec -> copySpec.from("src"));
+                        bad_helper(task);
+                    }
+                    public void bad_helper(Task task) {
+                        System.out.println("I am a happy squirrel");
+                        // BUG: Diagnostic contains: Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`
+                        task.getProject().copy(copySpec -> copySpec.into("dest"));
+                    }
+                }
+                """);
+    }
+}


### PR DESCRIPTION
## Before this PR

**PRs in sequence**: #222 -> #223 (curr)


We are rolling out the configuration cache. We are doing this [incrementally, one task at a time](https://github.com/palantir/gradle-incremental-configuration-cache). However, for incremental rollout to begin, [all configuration cache problems that occur in the configuration phase must be fixed](https://github.com/palantir/gradle-incremental-configuration-cache/pull/6). 

We've added an [errorprone](https://github.com/palantir/gradle-guide/pull/142) to prevent people from using `getProject` during the execution time. In most cases, when people do `getProject().X()` during execution time,  we can substitute it for another method which is configuration cache friendly — see these [metrics](https://pl.ntr/2vj). `getProject().copy()` is one such case, let's autofix these!


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Autofix `getProject().copy()` to `getFileSystemOperations().copy()`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
