### PR TITLE
Ban `task1.dependsOn(task2)`, unless if we think `task1` is a lifecycle task

### DIFF
--- a/errorprones.md
+++ b/errorprones.md
@@ -110,7 +110,7 @@ When defining a custom Task or Extension, you should make it an abstract class w
 </td>
 <td>
 
-Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
+Instead of `task1.dependsOn(task2)`, wire up the outputs of `task2` to the inputs of `task1` using providers.
 Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
 need `classes`. It is also a sign of bad task design. You should write tasks with explicit, fine-grained inputs
 and outputs. Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.

--- a/errorprones.md
+++ b/errorprones.md
@@ -98,5 +98,22 @@ When defining a custom Task or Extension, you should make it an abstract class w
 
 </td>
 </tr>
+
+<tr>
+<td>
+
+<a id="TaskDependsOn" href="guide/diagnosing-build-performance.md#needlessly-included-tasks">`TaskDependsOn`</a>
+
+</td>
+<td>
+<a href="guide/diagnosing-build-performance.md#needlessly-included-tasks">Please read</a>
+</td>
+<td>
+
+Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
+
+
+</td>
+</tr>
 </tbody>
 </table>

--- a/errorprones.md
+++ b/errorprones.md
@@ -112,8 +112,8 @@ When defining a custom Task or Extension, you should make it an abstract class w
 
 Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
 Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
-need `classes`. It also doesn't encourage you to write tasks with explicit, fine-grained inputs and outputs.
-Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
+need `classes`. It is also a sign of bad task design. You should write tasks with explicit, fine-grained inputs
+and outputs. Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
 
 However, there are cases where `dependsOn` is unavoidable:
 1. Wiring up tasks to lifecycle tasks e.g. `build.dependsOn(myTask)`

--- a/errorprones.md
+++ b/errorprones.md
@@ -111,6 +111,17 @@ When defining a custom Task or Extension, you should make it an abstract class w
 <td>
 
 Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
+Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
+need `classes`. It also doesn't encourage you to write tasks with explicit, fine-grained inputs and outputs.
+Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
+
+However, there are cases where `dependsOn` is unavoidable:
+1. Wiring up tasks to lifecycle tasks e.g. `build.dependsOn(myTask)`
+2. Tasks that do system-wide setup like installing npm. In these cases, we recommended that you specify the
+    installation directory as an `@OutputDirectory` of the task anyways.
+
+This errorprone tries to detect legitimate uses of `dependsOn`. You can suppress false positives, but we
+encourage you to do so sparingly, and think about whether something can be improved about your task design.
 
 
 </td>

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -28,7 +28,6 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -38,6 +37,9 @@ import java.util.Set;
         summary =
                 """
         Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
+        Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
+        need `classes`. It also doesn't encourage you to write tasks with explicit, fine-grained inputs and outputs.
+        Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
         """)
 public final class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
@@ -119,13 +121,6 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
         Type genericTaskType = state.getTypeFromString("org.gradle.api.Task");
         return ASTHelpers.isSubtype(task, genericTaskType, state)
                 && !ASTHelpers.isSameType(task, genericTaskType, state);
-    }
-
-    private static Type extractTaskType(ExpressionTree taskProvider) {
-        Type taskProviderType = ASTHelpers.getType(taskProvider);
-        Type.ClassType classType = (Type.ClassType) taskProviderType;
-        List<Type> typeArgs = classType.getTypeArguments();
-        return typeArgs.get(0);
     }
 
     @Override

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -23,15 +23,14 @@ import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
-import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.matchers.method.MethodMatchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Type;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -42,12 +41,41 @@ import java.util.Optional;
         """)
 public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
+    private static final Set<String> KNOWN_LIFECYCLE_TASKS = Set.of(
+            // Core bundling tasks
+            "org.gradle.api.tasks.bundling.Jar",
+            "org.gradle.api.tasks.bundling.War",
+            "org.gradle.api.tasks.bundling.Zip",
+            "org.gradle.api.tasks.bundling.Tar",
+
+            // Testing
+            "org.gradle.api.tasks.testing.Test",
+
+            // Compilation
+            "org.gradle.api.tasks.compile.JavaCompile",
+
+            // Documentation
+            "org.gradle.api.tasks.javadoc.Javadoc",
+
+            // Application
+            "org.gradle.api.tasks.JavaExec",
+            "org.gradle.api.tasks.application.CreateStartScripts",
+
+            // Quality
+            "org.gradle.api.plugins.quality.Checkstyle",
+            "com.github.spotbugs.snom.SpotBugsTask",
+
+            // Publishing
+            "org.gradle.api.publish.maven.tasks.PublishToMavenRepository",
+            "org.gradle.api.publish.maven.tasks.PublishToMavenLocal",
+            "org.gradle.api.publish.maven.tasks.GenerateMavenPom",
+
+            // Cleanup
+            "org.gradle.api.tasks.Delete");
+
     private static final Matcher<ExpressionTree> TASK_DEPENDS_ON = MethodMatchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Task")
             .named("dependsOn");
-
-    private static final Matcher<Tree> TASK_PROVIDER_SUBTYPE =
-            Matchers.isSubtypeOf("org.gradle.api.tasks.TaskProvider");
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -61,7 +89,7 @@ public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.M
         }
         ExpressionTree receiver = receiverMaybe.get();
 
-        if (!isCustomTask(receiver, state)) {
+        if (isKnownLifecycleTask(receiver, state)) {
             return Description.NO_MATCH;
         }
 
@@ -71,18 +99,31 @@ public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.M
                 .build();
     }
 
-    /**
-     * @param arg Any expression you can pass to {@code Task::dependsOn} — <a href="https://docs.gradle.org/current/javadoc/org/gradle/api/Task.html#dependencies">list in docs</a>
-     */
-    private static boolean isCustomTask(ExpressionTree arg, VisitorState state) {
-        Type taskType =
-                TASK_PROVIDER_SUBTYPE.matches(arg, state) ? extractTaskType(arg, state) : ASTHelpers.getType(arg);
-        Type genericTaskType = state.getTypeFromString("org.gradle.api.Task");
-        return ASTHelpers.isSubtype(taskType, genericTaskType, state)
-                && !ASTHelpers.isSameType(taskType, genericTaskType, state);
+    private static boolean isKnownLifecycleTask(ExpressionTree task, VisitorState state) {
+        Type taskType = ASTHelpers.getType(task);
+
+        // We assume people don't write custom types for lifecycle tasks
+        if (!isCustomTask(taskType, state)) {
+            return true;
+        }
+
+        for (String lifecycleType : KNOWN_LIFECYCLE_TASKS) {
+            Type knownType = state.getTypeFromString(lifecycleType);
+            if (ASTHelpers.isSameType(taskType, knownType, state)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    private static Type extractTaskType(ExpressionTree taskProvider, VisitorState state) {
+    private static boolean isCustomTask(Type task, VisitorState state) {
+        Type genericTaskType = state.getTypeFromString("org.gradle.api.Task");
+        return ASTHelpers.isSubtype(task, genericTaskType, state)
+                && !ASTHelpers.isSameType(task, genericTaskType, state);
+    }
+
+    private static Type extractTaskType(ExpressionTree taskProvider) {
         Type taskProviderType = ASTHelpers.getType(taskProvider);
         Type.ClassType classType = (Type.ClassType) taskProviderType;
         List<Type> typeArgs = classType.getTypeArguments();

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -88,8 +88,14 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
             return Description.NO_MATCH;
         }
         ExpressionTree receiver = receiverMaybe.get();
+        Type taskType = ASTHelpers.getType(receiver);
 
-        if (isKnownLifecycleTask(receiver, state)) {
+        // It's alright to wire up lifecycle tasks with dependsOn
+        if (isKnownLifecycleTask(taskType, state)) {
+            return Description.NO_MATCH;
+        }
+        // We assume people don't write custom types for lifecycle tasks
+        if (!isCustomTask(taskType, state)) {
             return Description.NO_MATCH;
         }
 
@@ -99,22 +105,11 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
                 .build();
     }
 
-    private static boolean isKnownLifecycleTask(ExpressionTree task, VisitorState state) {
-        Type taskType = ASTHelpers.getType(task);
-
-        // We assume people don't write custom types for lifecycle tasks
-        if (!isCustomTask(taskType, state)) {
-            return true;
-        }
-
-        for (String lifecycleType : KNOWN_LIFECYCLE_TASKS) {
-            Type knownType = state.getTypeFromString(lifecycleType);
-            if (ASTHelpers.isSameType(taskType, knownType, state)) {
-                return true;
-            }
-        }
-
-        return false;
+    private static boolean isKnownLifecycleTask(Type task, VisitorState state) {
+        return KNOWN_LIFECYCLE_TASKS.stream().anyMatch(lifecycle -> {
+            Type knownLifecycletask = state.getTypeFromString(lifecycle);
+            return ASTHelpers.isSameType(task, knownLifecycletask, state);
+        });
     }
 
     private static boolean isCustomTask(Type task, VisitorState state) {

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -1,0 +1,96 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
+import java.util.Optional;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        severity = SeverityLevel.ERROR,
+        summary =
+                """
+        Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
+        """)
+public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
+
+    private static final Matcher<ExpressionTree> TASK_DEPENDS_ON = MethodMatchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Task")
+            .named("dependsOn");
+
+    private static final Matcher<Tree> TASK_PROVIDER_SUBTYPE =
+            Matchers.isSubtypeOf("org.gradle.api.tasks.TaskProvider");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!TASK_DEPENDS_ON.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        Optional<ExpressionTree> receiverMaybe = Optional.ofNullable(ASTHelpers.getReceiver(tree));
+        if (receiverMaybe.isEmpty()) {
+            return Description.NO_MATCH;
+        }
+        ExpressionTree receiver = receiverMaybe.get();
+
+        if (!isCustomTask(receiver, state)) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree)
+                .setMessage(
+                        "Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers")
+                .build();
+    }
+
+    /**
+     * @param arg Any expression you can pass to {@code Task::dependsOn} — <a href="https://docs.gradle.org/current/javadoc/org/gradle/api/Task.html#dependencies">list in docs</a>
+     */
+    private static boolean isCustomTask(ExpressionTree arg, VisitorState state) {
+        Type taskType =
+                TASK_PROVIDER_SUBTYPE.matches(arg, state) ? extractTaskType(arg, state) : ASTHelpers.getType(arg);
+        Type genericTaskType = state.getTypeFromString("org.gradle.api.Task");
+        return ASTHelpers.isSubtype(taskType, genericTaskType, state)
+                && !ASTHelpers.isSameType(taskType, genericTaskType, state);
+    }
+
+    private static Type extractTaskType(ExpressionTree taskProvider, VisitorState state) {
+        Type taskProviderType = ASTHelpers.getType(taskProvider);
+        Type.ClassType classType = (Type.ClassType) taskProviderType;
+        List<Type> typeArgs = classType.getTypeArguments();
+        return typeArgs.get(0);
+    }
+
+    @Override
+    public MoreInfoLink moreInfoLink() {
+        return null;
+    }
+}

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -24,6 +24,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.method.MethodMatchers;
+import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -31,28 +32,27 @@ import com.sun.tools.javac.code.Type;
 import java.util.Optional;
 
 @AutoService(BugChecker.class)
-@BugPattern(
-        severity = SeverityLevel.ERROR,
-        summary =
-                """
-        Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
-        Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
-        need `classes`. It is also a sign of bad task design. You should write tasks with explicit, fine-grained inputs
-        and outputs. Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
+@BugPattern(severity = SeverityLevel.ERROR, summary = """
+    Instead of `task1.dependsOn(task2)`, wire up the outputs of `task2` to the inputs of `task1` using providers.
+    Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
+    need `classes`. It is also a sign of bad task design. You should write tasks with explicit, fine-grained inputs
+    and outputs. Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
 
-        However, there are cases where `dependsOn` is unavoidable:
-        1. Wiring up tasks to lifecycle tasks e.g. `build.dependsOn(myTask)`
-        2. Tasks that do system-wide setup like installing npm. In these cases, we recommended that you specify the
-            installation directory as an `@OutputDirectory` of the task anyways.
+    However, there are cases where `dependsOn` is unavoidable:
+    1. Wiring up tasks to lifecycle tasks e.g. `build.dependsOn(myTask)`
+    2. Tasks that do system-wide setup like installing npm. In these cases, we recommended that you specify the
+        installation directory as an `@OutputDirectory` of the task anyways.
 
-        This errorprone tries to detect legitimate uses of `dependsOn`. You can suppress false positives, but we
-        encourage you to do so sparingly, and think about whether something can be improved about your task design.
-        """)
+    This errorprone tries to detect legitimate uses of `dependsOn`. You can suppress false positives, but we
+    encourage you to do so sparingly, and think about whether something can be improved about your task design.
+    """)
 public final class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final Matcher<ExpressionTree> TASK_DEPENDS_ON = MethodMatchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Task")
             .named("dependsOn");
+    private static final Supplier<Type> DEFAULT_TASK_TYPE =
+            VisitorState.memoize(state -> state.getTypeFromString("org.gradle.api.DefaultTask"));
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
@@ -73,12 +73,12 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
 
         return buildDescription(tree)
                 .setMessage("Instead of `task1.dependsOn(task2)`, "
-                        + "wire up the outputs of task2 to the inputs of task1 using providers")
+                        + "wire up the outputs of `task2` to the inputs of `task1` using providers")
                 .build();
     }
 
     private static boolean isCustomTask(Type task, VisitorState state) {
-        Type genericTaskType = state.getTypeFromString("org.gradle.api.DefaultTask");
+        Type genericTaskType = DEFAULT_TASK_TYPE.get(state);
         return ASTHelpers.isSubtype(task, genericTaskType, state)
                 && !ASTHelpers.isSameType(task, genericTaskType, state);
     }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -39,7 +39,7 @@ import java.util.Set;
                 """
         Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
         """)
-public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
+public final class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
     private static final Set<String> KNOWN_LIFECYCLE_TASKS = Set.of(
             // Core bundling tasks
@@ -94,8 +94,8 @@ public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.M
         }
 
         return buildDescription(tree)
-                .setMessage(
-                        "Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers")
+                .setMessage("Instead of `task1.dependsOn(task2)`, "
+                        + "wire up the outputs of task2 to the inputs of task1 using providers")
                 .build();
     }
 
@@ -132,6 +132,6 @@ public class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.M
 
     @Override
     public MoreInfoLink moreInfoLink() {
-        return null;
+        return new MoreInfoHeadingLink("diagnosing-build-performance.md", "Needlessly included tasks");
     }
 }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -77,6 +77,9 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
             .onDescendantOf("org.gradle.api.Task")
             .named("dependsOn");
 
+    /**
+     * FELIX's SUGGESTION — MAKE @LifecycleTask an annotation
+     */
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (!TASK_DEPENDS_ON.matches(tree, state)) {

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -29,7 +29,6 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.code.Type;
 import java.util.Optional;
-import java.util.Set;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -38,8 +37,8 @@ import java.util.Set;
                 """
         Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers.
         Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
-        need `classes`. It also doesn't encourage you to write tasks with explicit, fine-grained inputs and outputs.
-        Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
+        need `classes`. It is also a sign of bad task design. You should write tasks with explicit, fine-grained inputs
+        and outputs. Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
 
         However, there are cases where `dependsOn` is unavoidable:
         1. Wiring up tasks to lifecycle tasks e.g. `build.dependsOn(myTask)`
@@ -50,38 +49,6 @@ import java.util.Set;
         encourage you to do so sparingly, and think about whether something can be improved about your task design.
         """)
 public final class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
-
-    private static final Set<String> KNOWN_LIFECYCLE_TASKS = Set.of(
-            // Core bundling tasks
-            "org.gradle.api.tasks.bundling.Jar",
-            "org.gradle.api.tasks.bundling.War",
-            "org.gradle.api.tasks.bundling.Zip",
-            "org.gradle.api.tasks.bundling.Tar",
-
-            // Testing
-            "org.gradle.api.tasks.testing.Test",
-
-            // Compilation
-            "org.gradle.api.tasks.compile.JavaCompile",
-
-            // Documentation
-            "org.gradle.api.tasks.javadoc.Javadoc",
-
-            // Application
-            "org.gradle.api.tasks.JavaExec",
-            "org.gradle.api.tasks.application.CreateStartScripts",
-
-            // Quality
-            "org.gradle.api.plugins.quality.Checkstyle",
-            "com.github.spotbugs.snom.SpotBugsTask",
-
-            // Publishing
-            "org.gradle.api.publish.maven.tasks.PublishToMavenRepository",
-            "org.gradle.api.publish.maven.tasks.PublishToMavenLocal",
-            "org.gradle.api.publish.maven.tasks.GenerateMavenPom",
-
-            // Cleanup
-            "org.gradle.api.tasks.Delete");
 
     private static final Matcher<ExpressionTree> TASK_DEPENDS_ON = MethodMatchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Task")
@@ -100,11 +67,6 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
         ExpressionTree receiver = receiverMaybe.get();
         Type taskType = ASTHelpers.getType(receiver);
 
-        // It's alright to wire up lifecycle tasks with dependsOn
-        if (isKnownLifecycleTask(taskType, state)) {
-            return Description.NO_MATCH;
-        }
-        // We assume people don't write custom types for lifecycle tasks
         if (!isCustomTask(taskType, state)) {
             return Description.NO_MATCH;
         }
@@ -115,15 +77,8 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
                 .build();
     }
 
-    private static boolean isKnownLifecycleTask(Type task, VisitorState state) {
-        return KNOWN_LIFECYCLE_TASKS.stream().anyMatch(lifecycle -> {
-            Type knownLifecycletask = state.getTypeFromString(lifecycle);
-            return ASTHelpers.isSameType(task, knownLifecycletask, state);
-        });
-    }
-
     private static boolean isCustomTask(Type task, VisitorState state) {
-        Type genericTaskType = state.getTypeFromString("org.gradle.api.Task");
+        Type genericTaskType = state.getTypeFromString("org.gradle.api.DefaultTask");
         return ASTHelpers.isSubtype(task, genericTaskType, state)
                 && !ASTHelpers.isSameType(task, genericTaskType, state);
     }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/TaskDependsOn.java
@@ -40,6 +40,14 @@ import java.util.Set;
         Using `dependsOn` makes it easy to add unnecessary task dependencies — e.g. depending on `jar` when you just
         need `classes`. It also doesn't encourage you to write tasks with explicit, fine-grained inputs and outputs.
         Having unnecessary dependencies adds unnecessary work to a build and hurts task parallelism.
+
+        However, there are cases where `dependsOn` is unavoidable:
+        1. Wiring up tasks to lifecycle tasks e.g. `build.dependsOn(myTask)`
+        2. Tasks that do system-wide setup like installing npm. In these cases, we recommended that you specify the
+            installation directory as an `@OutputDirectory` of the task anyways.
+
+        This errorprone tries to detect legitimate uses of `dependsOn`. You can suppress false positives, but we
+        encourage you to do so sparingly, and think about whether something can be improved about your task design.
         """)
 public final class TaskDependsOn extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
 
@@ -79,9 +87,6 @@ public final class TaskDependsOn extends GradleGuideBugChecker implements BugChe
             .onDescendantOf("org.gradle.api.Task")
             .named("dependsOn");
 
-    /**
-     * FELIX's SUGGESTION — MAKE @LifecycleTask an annotation
-     */
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (!TASK_DEPENDS_ON.matches(tree, state)) {

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
@@ -24,35 +24,33 @@ class TaskDependsOnTest {
     private final CompilationTestHelper compilationTestHelper =
             CompilationTestHelper.newInstance(TaskDependsOn.class, getClass());
 
+    // language=Java
+    private final String TEST_SETUP =
+            """
+            import java.io.File;
+            import org.gradle.api.*;
+            import org.gradle.api.file.*;
+            import org.gradle.api.provider.*;
+            import org.gradle.api.tasks.*;
+            import org.gradle.api.tasks.testing.*;
+            import org.gradle.api.tasks.bundling.*;
+
+            abstract class ProducingTask extends DefaultTask {
+                @OutputFile
+                public abstract RegularFileProperty getOutputFile();
+            }
+
+            abstract class ConsumingTask extends DefaultTask {
+                @InputFile
+                public abstract RegularFileProperty getInputFile();
+            }
+    """;
+
     @Test
-    void should_fix_getProject_getLogger() {
+    void dependsOn_subclass_of_task_should_fail() {
         test(
                 """
-            import java.io.File;
-            import org.gradle.api.Plugin;
-            import org.gradle.api.Project;
-            import org.gradle.api.DefaultTask;
-            import org.gradle.api.file.RegularFile;
-            import org.gradle.api.file.RegularFileProperty;
-            import org.gradle.api.provider.Provider;
-            import org.gradle.api.tasks.Input;
-            import org.gradle.api.tasks.InputFile;
-            import org.gradle.api.tasks.OutputFile;
-            import org.gradle.api.tasks.TaskAction;
-            import org.gradle.api.tasks.TaskProvider;
-
             abstract class MyPlugin implements Plugin<Project> {
-
-                abstract class ProducingTask extends DefaultTask {
-                    @OutputFile
-                    public abstract RegularFileProperty getOutputFile();
-                }
-
-                abstract class ConsumingTask extends DefaultTask {
-                    @InputFile
-                    public abstract RegularFileProperty getInputFile();
-                }
-
                 @Override
                 public final void apply(Project project) {
                     Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
@@ -67,12 +65,73 @@ class TaskDependsOnTest {
                         task.dependsOn(producingTask);
                     });
 
+                    consumingTask.configure(task -> {
+                        // BUG: Diagnostic contains: Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers
+                        task.dependsOn(producingTask);
+                    });
+                }
+            }
+        """);
+    }
+
+    @Test
+    void dependsOn_generic_task_should_pass() {
+        test(
+                """
+            abstract class MyPlugin implements Plugin<Project> {
+                @Override
+                public final void apply(Project project) {
+                    Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
+
+                    TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
+                        task.getOutputFile().set(sharedFile);
+                    });
+
+                    TaskProvider<?> lifecycleTask = project.getTasks().register("lifecycleTask");
+                    Task check = project.getTasks().getByName("check");
+                    project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
+                        task.getInputFile().set(sharedFile);
+
+                        // These are OK, because we assume that all lifecycle tasks to be non-custom, regular `Task`s
+                        lifecycleTask.configure(lifecycle -> lifecycle.dependsOn(task));
+                        check.dependsOn(check);
+                    });
+
+                    TaskProvider<Task> consumingTask = project.getTasks().named("consumingTask");
+                    consumingTask.configure(task -> {
+                        // Ideally we'd catch this case, but we don't know whether producingTask is actually a custom task or not, so be conservative
+                        task.dependsOn(producingTask);
+                    });
+                }
+            }
+        """);
+    }
+
+    @Test
+    void dependsOn_known_lifecycle_task_should_pass() {
+        test(
+                """
+            abstract class MyPlugin implements Plugin<Project> {
+                @Override
+                public final void apply(Project project) {
+                    Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
+
+                    TaskProvider<Jar> jarTask = project.getTasks().named("jar", Jar.class);
+                    TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
+
+                    TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
+                        task.getOutputFile().set(sharedFile);
+                        // These are okay, as Jar and Test are lifecycle tasks
+                        jarTask.configure(jar -> jar.dependsOn(task));
+                        testTasks.configureEach(test -> test.dependsOn(task));
+                        project.getTasks().named("check").configure(check -> check.dependsOn(task));
+                    });
                 }
             }
         """);
     }
 
     private void test(@Language("Java") String source) {
-        compilationTestHelper.addSourceLines("Test.java", source).doTest();
+        compilationTestHelper.addSourceLines("Test.java", TEST_SETUP + source).doTest();
     }
 }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
@@ -20,12 +20,13 @@ import com.google.errorprone.CompilationTestHelper;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("LineLength")
 class TaskDependsOnTest {
     private final CompilationTestHelper compilationTestHelper =
             CompilationTestHelper.newInstance(TaskDependsOn.class, getClass());
 
     // language=Java
-    private final String TEST_SETUP =
+    private final String testSetup =
             """
             import java.io.File;
             import org.gradle.api.*;
@@ -98,9 +99,9 @@ class TaskDependsOnTest {
                     });
 
                     TaskProvider<Task> consumingTask = project.getTasks().named("consumingTask");
-                    consumingTask.configure(task -> {
-                        // Ideally we'd catch this case, but we don't know whether producingTask is actually a custom task or not, so be conservative
-                        task.dependsOn(producingTask);
+                    consumingTask.configure(genericTask -> {
+                        // Ideally we'd catch this case, but we don't know whether consumingTask is actually a custom task or not, so be conservative
+                        genericTask.dependsOn(producingTask);
                     });
                 }
             }
@@ -121,7 +122,7 @@ class TaskDependsOnTest {
 
                     TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
                         task.getOutputFile().set(sharedFile);
-                        // These are okay, as Jar and Test are lifecycle tasks
+                        // These are okay, as Jar, Test, and check are lifecycle tasks
                         jarTask.configure(jar -> jar.dependsOn(task));
                         testTasks.configureEach(test -> test.dependsOn(task));
                         project.getTasks().named("check").configure(check -> check.dependsOn(task));
@@ -132,6 +133,6 @@ class TaskDependsOnTest {
     }
 
     private void test(@Language("Java") String source) {
-        compilationTestHelper.addSourceLines("Test.java", TEST_SETUP + source).doTest();
+        compilationTestHelper.addSourceLines("Test.java", testSetup + source).doTest();
     }
 }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
@@ -48,7 +48,7 @@ class TaskDependsOnTest {
     """;
 
     @Test
-    void dependsOn_subclass_of_task_should_fail() {
+    void dependsOn_custom_task_subtype_should_fail() {
         test(
                 """
             abstract class MyPlugin implements Plugin<Project> {
@@ -76,7 +76,7 @@ class TaskDependsOnTest {
     }
 
     @Test
-    void dependsOn_generic_task_should_pass() {
+    void dependsOn_DefaultTask_should_pass() {
         test(
                 """
             abstract class MyPlugin implements Plugin<Project> {
@@ -93,39 +93,15 @@ class TaskDependsOnTest {
                     project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
                         task.getInputFile().set(sharedFile);
 
-                        // These are OK, because we assume that all lifecycle tasks to be non-custom, regular `Task`s
+                        // These are OK, because we assume that a regular DefaultTask is a lifecycle task
                         lifecycleTask.configure(lifecycle -> lifecycle.dependsOn(task));
-                        check.dependsOn(check);
+                        check.dependsOn(task);
                     });
 
                     TaskProvider<Task> consumingTask = project.getTasks().named("consumingTask");
                     consumingTask.configure(genericTask -> {
                         // Ideally we'd catch this case, but we don't know whether consumingTask is actually a custom task or not, so be conservative
                         genericTask.dependsOn(producingTask);
-                    });
-                }
-            }
-        """);
-    }
-
-    @Test
-    void dependsOn_known_lifecycle_task_should_pass() {
-        test(
-                """
-            abstract class MyPlugin implements Plugin<Project> {
-                @Override
-                public final void apply(Project project) {
-                    Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
-
-                    TaskProvider<Jar> jarTask = project.getTasks().named("jar", Jar.class);
-                    TaskCollection<Test> testTasks = project.getTasks().withType(Test.class);
-
-                    TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
-                        task.getOutputFile().set(sharedFile);
-                        // These are okay, as Jar, Test, and check are lifecycle tasks
-                        jarTask.configure(jar -> jar.dependsOn(task));
-                        testTasks.configureEach(test -> test.dependsOn(task));
-                        project.getTasks().named("check").configure(check -> check.dependsOn(task));
                     });
                 }
             }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
@@ -26,86 +26,83 @@ class TaskDependsOnTest {
             CompilationTestHelper.newInstance(TaskDependsOn.class, getClass());
 
     // language=Java
-    private final String testSetup =
-            """
-            import java.io.File;
-            import org.gradle.api.*;
-            import org.gradle.api.file.*;
-            import org.gradle.api.provider.*;
-            import org.gradle.api.tasks.*;
-            import org.gradle.api.tasks.testing.*;
-            import org.gradle.api.tasks.bundling.*;
+    private final String testSetup = """
+                import java.io.File;
+                import org.gradle.api.*;
+                import org.gradle.api.file.*;
+                import org.gradle.api.provider.*;
+                import org.gradle.api.tasks.*;
+                import org.gradle.api.tasks.testing.*;
+                import org.gradle.api.tasks.bundling.*;
 
-            abstract class ProducingTask extends DefaultTask {
-                @OutputFile
-                public abstract RegularFileProperty getOutputFile();
-            }
+                abstract class ProducingTask extends DefaultTask {
+                    @OutputFile
+                    public abstract RegularFileProperty getOutputFile();
+                }
 
-            abstract class ConsumingTask extends DefaultTask {
-                @InputFile
-                public abstract RegularFileProperty getInputFile();
-            }
-    """;
+                abstract class ConsumingTask extends DefaultTask {
+                    @InputFile
+                    public abstract RegularFileProperty getInputFile();
+                }
+        """;
 
     @Test
     void dependsOn_custom_task_subtype_should_fail() {
-        test(
-                """
-            abstract class MyPlugin implements Plugin<Project> {
-                @Override
-                public final void apply(Project project) {
-                    Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
+        test("""
+                abstract class MyPlugin implements Plugin<Project> {
+                    @Override
+                    public final void apply(Project project) {
+                        Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
 
-                    TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
-                        task.getOutputFile().set(sharedFile);
-                    });
+                        TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
+                            task.getOutputFile().set(sharedFile);
+                        });
 
-                    TaskProvider<ConsumingTask> consumingTask = project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
-                        task.getInputFile().set(sharedFile);
-                        // BUG: Diagnostic contains: Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers
-                        task.dependsOn(producingTask);
-                    });
+                        TaskProvider<ConsumingTask> consumingTask = project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
+                            task.getInputFile().set(sharedFile);
+                            // BUG: Diagnostic contains: Instead of `task1.dependsOn(task2)`, wire up the outputs of `task2` to the inputs of `task1` using providers
+                            task.dependsOn(producingTask);
+                        });
 
-                    consumingTask.configure(task -> {
-                        // BUG: Diagnostic contains: Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers
-                        task.dependsOn(producingTask);
-                    });
+                        consumingTask.configure(task -> {
+                            // BUG: Diagnostic contains: Instead of `task1.dependsOn(task2)`, wire up the outputs of `task2` to the inputs of `task1` using providers
+                            task.dependsOn(producingTask);
+                        });
+                    }
                 }
-            }
-        """);
+            """);
     }
 
     @Test
     void dependsOn_DefaultTask_should_pass() {
-        test(
-                """
-            abstract class MyPlugin implements Plugin<Project> {
-                @Override
-                public final void apply(Project project) {
-                    Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
+        test("""
+                abstract class MyPlugin implements Plugin<Project> {
+                    @Override
+                    public final void apply(Project project) {
+                        Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
 
-                    TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
-                        task.getOutputFile().set(sharedFile);
-                    });
+                        TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
+                            task.getOutputFile().set(sharedFile);
+                        });
 
-                    TaskProvider<?> lifecycleTask = project.getTasks().register("lifecycleTask");
-                    Task check = project.getTasks().getByName("check");
-                    project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
-                        task.getInputFile().set(sharedFile);
+                        TaskProvider<?> lifecycleTask = project.getTasks().register("lifecycleTask");
+                        Task check = project.getTasks().getByName("check");
+                        project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
+                            task.getInputFile().set(sharedFile);
 
-                        // These are OK, because we assume that a regular DefaultTask is a lifecycle task
-                        lifecycleTask.configure(lifecycle -> lifecycle.dependsOn(task));
-                        check.dependsOn(task);
-                    });
+                            // These are OK, because we assume that a regular DefaultTask is a lifecycle task
+                            lifecycleTask.configure(lifecycle -> lifecycle.dependsOn(task));
+                            check.dependsOn(task);
+                        });
 
-                    TaskProvider<Task> consumingTask = project.getTasks().named("consumingTask");
-                    consumingTask.configure(genericTask -> {
-                        // Ideally we'd catch this case, but we don't know whether consumingTask is actually a custom task or not, so be conservative
-                        genericTask.dependsOn(producingTask);
-                    });
+                        TaskProvider<Task> consumingTask = project.getTasks().named("consumingTask");
+                        consumingTask.configure(genericTask -> {
+                            // Ideally we'd catch this case, but we don't know whether consumingTask is actually a custom task or not, so be conservative
+                            genericTask.dependsOn(producingTask);
+                        });
+                    }
                 }
-            }
-        """);
+            """);
     }
 
     private void test(@Language("Java") String source) {

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/TaskDependsOnTest.java
@@ -1,0 +1,78 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+class TaskDependsOnTest {
+    private final CompilationTestHelper compilationTestHelper =
+            CompilationTestHelper.newInstance(TaskDependsOn.class, getClass());
+
+    @Test
+    void should_fix_getProject_getLogger() {
+        test(
+                """
+            import java.io.File;
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.file.RegularFile;
+            import org.gradle.api.file.RegularFileProperty;
+            import org.gradle.api.provider.Provider;
+            import org.gradle.api.tasks.Input;
+            import org.gradle.api.tasks.InputFile;
+            import org.gradle.api.tasks.OutputFile;
+            import org.gradle.api.tasks.TaskAction;
+            import org.gradle.api.tasks.TaskProvider;
+
+            abstract class MyPlugin implements Plugin<Project> {
+
+                abstract class ProducingTask extends DefaultTask {
+                    @OutputFile
+                    public abstract RegularFileProperty getOutputFile();
+                }
+
+                abstract class ConsumingTask extends DefaultTask {
+                    @InputFile
+                    public abstract RegularFileProperty getInputFile();
+                }
+
+                @Override
+                public final void apply(Project project) {
+                    Provider<RegularFile> sharedFile = project.getLayout().getBuildDirectory().file("happy-squirrel.txt");
+
+                    TaskProvider<ProducingTask> producingTask = project.getTasks().register("producingTask", ProducingTask.class, task -> {
+                        task.getOutputFile().set(sharedFile);
+                    });
+
+                    TaskProvider<ConsumingTask> consumingTask = project.getTasks().register("consumingTask", ConsumingTask.class, task -> {
+                        task.getInputFile().set(sharedFile);
+                        // BUG: Diagnostic contains: Instead of `task1.dependsOn(task2)`, wire up the outputs of task2 to the inputs of task1 using providers
+                        task.dependsOn(producingTask);
+                    });
+
+                }
+            }
+        """);
+    }
+
+    private void test(@Language("Java") String source) {
+        compilationTestHelper.addSourceLines("Test.java", source).doTest();
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

`task1.dependsOn(task2)` is a sign of bad task design, and can cause tasks to be run when unnecessary. Lets ban it.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ban `task1.dependsOn(task2)`, unless if we think task1 is a lifecycle task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

