### PR TITLE
Autofix `getProject().getLayout()` and `getProject().getBuildDir()`

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -103,10 +103,9 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
                     GradleService.PROJECT_LAYOUT, Replacement.literal("getProjectDirectory().getAsFile()")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_BUILD_DIR = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, getBuildDir),
-            "Instead of `getProject().getBuildDir()`, do `getProjectLayout().getBuildDirectory().file('.').get().getAsFile()`",
+            "Instead of `getProject().getBuildDir()`, do `getProjectLayout().getBuildDirectory().getAsFile().get()`",
             GradleFix.onService(
-                    GradleService.PROJECT_LAYOUT,
-                    Replacement.literal("getBuildDirectory().file(\".\").get().getAsFile()")));
+                    GradleService.PROJECT_LAYOUT, Replacement.literal("getBuildDirectory().getAsFile().get()")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_COPY = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, copy),
             "Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`",

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -103,7 +103,7 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
                     GradleService.PROJECT_LAYOUT, Replacement.literal("getProjectDirectory().getAsFile()")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_BUILD_DIR = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, getBuildDir),
-            "Instead of `getProject().getBuildDir()`, do `getProjectLayout().getProjectDirectory().getAsFile()`",
+            "Instead of `getProject().getBuildDir()`, do `getProjectLayout().getBuildDirectory().file('.').get().getAsFile()`",
             GradleFix.onService(
                     GradleService.PROJECT_LAYOUT,
                     Replacement.literal("getBuildDirectory().file(\".\").get().getAsFile()")));

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -69,9 +69,17 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .onDescendantOf("org.gradle.api.Project")
             .named("getLogger")
             .withNoParameters();
+    private static final Matcher<ExpressionTree> getLayout = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("getLayout")
+            .withNoParameters();
     private static final Matcher<ExpressionTree> getProjectDir = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Project")
             .named("getProjectDir")
+            .withNoParameters();
+    private static final Matcher<ExpressionTree> getBuildDir = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("getBuildDir")
             .withNoParameters();
     private static final Matcher<ExpressionTree> copy = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Project")
@@ -84,12 +92,21 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             ChainedCallMatcher.of(getProject, getLogger),
             "Instead of `getProject().getLogger()`, just do `getLogger()`",
             GradleFix.onThis(Replacement.literal("getLogger()")));
-
+    private static final TaskExecutionViolation FIX_GET_PROJECT_GET_LAYOUT = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, getLayout),
+            "Instead of `getProject().getLayout()`, do `getProjectLayout()`",
+            GradleFix.onService(GradleService.PROJECT_LAYOUT, Replacement.literal("")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_PROJECT_DIR = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, getProjectDir),
             "Instead of `getProject().getProjectDir()`, do `getProjectLayout().getProjectDirectory().getAsFile()`",
             GradleFix.onService(
                     GradleService.PROJECT_LAYOUT, Replacement.literal("getProjectDirectory().getAsFile()")));
+    private static final TaskExecutionViolation FIX_GET_PROJECT_GET_BUILD_DIR = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, getBuildDir),
+            "Instead of `getProject().getBuildDir()`, do `getProjectLayout().getProjectDirectory().getAsFile()`",
+            GradleFix.onService(
+                    GradleService.PROJECT_LAYOUT,
+                    Replacement.literal("getBuildDirectory().file(\".\").get().getAsFile()")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_COPY = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, copy),
             "Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`",
@@ -97,7 +114,9 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
 
     private static final List<TaskExecutionViolation> violationsInOrderOfSpecificity = Stream.of(
                     FIX_GET_PROJECT_COPY,
+                    FIX_GET_PROJECT_GET_BUILD_DIR,
                     FIX_GET_PROJECT_GET_PROJECT_DIR,
+                    FIX_GET_PROJECT_GET_LAYOUT,
                     FIX_GET_PROJECT_GET_LOGGER,
                     REPORT_GET_PROJECT)
             .sorted()

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleFix.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleFix.java
@@ -104,6 +104,16 @@ public record GradleFix(Optional<GradleService> service, Replacement replacement
     public record GradleFixContext(
             MethodInvocationTree illegalCallToReplace, int violatingChainLength, TaskOrAction enclosingClass) {}
 
+    private static String chain(String expr1, String expr2) {
+        if (expr1.isEmpty()) {
+            return expr2;
+        } else if (expr2.isEmpty()) {
+            return expr1;
+        } else {
+            return expr1 + "." + expr2;
+        }
+    }
+
     public SuggestedFix render(GradleFixContext context, VisitorState state) {
         Preconditions.checkArgument(
                 context.enclosingClass().type() == Variant.TASK || !requiresServiceInjection(),
@@ -115,7 +125,7 @@ public record GradleFix(Optional<GradleService> service, Replacement replacement
         String serviceReceiver = getServiceReceiver(context, state, fixBuilder);
 
         // Preserve arguments (if any)
-        String fixedCallChain = serviceReceiver + replacement.render(context.illegalCallToReplace, state);
+        String fixedCallChain = chain(serviceReceiver, replacement.render(context.illegalCallToReplace, state));
 
         // Preserve receiver
         MethodInvocationTree innermost = context.illegalCallToReplace;
@@ -149,11 +159,11 @@ public record GradleFix(Optional<GradleService> service, Replacement replacement
         Optional<String> serviceReceiverMaybe =
                 findServiceReceiver(gradleService, context.enclosingClass().tree(), state);
         if (serviceReceiverMaybe.isPresent()) {
-            return serviceReceiverMaybe.get() + ".";
+            return serviceReceiverMaybe.get();
         }
 
         injectService(context, state, gradleService, fixBuilder);
-        return gradleService.defaultGetterName() + "().";
+        return gradleService.defaultGetterName() + "()";
     }
 
     private static void injectService(

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/GetProjectGetProjectDirTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/GetProjectGetProjectDirTest.java
@@ -35,6 +35,7 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                     @TaskAction
                     final void action() {
                         File projectDir = getProject().getProjectDir();
+                        File buildDir = getProject().getBuildDir();
                     }
                 }
             """,
@@ -54,6 +55,7 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                     @TaskAction
                     final void action() {
                         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
+                        File buildDir = getProjectLayout().getBuildDirectory().file(".").get().getAsFile();
                     }
                 }
             """);
@@ -81,7 +83,9 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                     @TaskAction
                     final void action() {
                         getProjectLayout().getSettingsDirectory().file(IM_AT_THE_TOP_OF_THE_CLASS);
+                        ProjectLayout projectLayout = getProject().getLayout();
                         File projectDir = getProject().getProjectDir();
+                        File buildDir = getProject().getBuildDir();
                     }
                 }
             """,
@@ -103,7 +107,9 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                     @TaskAction
                     final void action() {
                         getProjectLayout().getSettingsDirectory().file(IM_AT_THE_TOP_OF_THE_CLASS);
+                        ProjectLayout projectLayout = getProjectLayout();
                         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
+                        File buildDir = getProjectLayout().getBuildDirectory().file(".").get().getAsFile();
                     }
                 }
             """);
@@ -118,12 +124,15 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                 import org.gradle.api.DefaultTask;
                 import org.gradle.api.Plugin;
                 import org.gradle.api.Project;
+                import org.gradle.api.file.ProjectLayout;
                 import org.gradle.api.tasks.TaskAction;
 
                 class ConcreteTask extends DefaultTask {
                     @TaskAction
                     final void action() {
+                        ProjectLayout projectLayout = getProject().getLayout();
                         File projectDir = getProject().getProjectDir();
+                        File buildDir = getProject().getBuildDir();
                     }
                 }
             """,
@@ -142,7 +151,9 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
 
                     @TaskAction
                     final void action() {
+                        ProjectLayout projectLayout = getProjectLayout();
                         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
+                        File buildDir = getProjectLayout().getBuildDirectory().file(".").get().getAsFile();
                     }
                 }
             """);
@@ -160,13 +171,19 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
             public void execute(Task task) {
                 // BUG: Diagnostic contains: Instead of `getProject().getProjectDir()`, do `getProjectLayout().getProjectDirectory().getAsFile()`
                 task.getProject().getProjectDir();
-                bad_helper(task);
+                badHelper(task);
             }
 
-            public void bad_helper(Task task) {
+            public void badHelper(Task task) {
                 System.out.println("I am a happy squirrel");
                 // BUG: Diagnostic contains: Instead of `getProject().getProjectDir()`, do `getProjectLayout().getProjectDirectory().getAsFile()`
                 task.getProject().getProjectDir();
+                badHelper2(task);
+            }
+
+            public void badHelper2(Task task) {
+                // BUG: Diagnostic contains: Instead of `getProject().getLayout()`, do `getProjectLayout()`
+                task.getProject().getLayout();
             }
         }
         """);

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ProjectLayoutFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ProjectLayoutFixesTest.java
@@ -19,7 +19,7 @@ package com.palantir.gradle.guide.errorprone.taskexecution;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("LineLength")
-public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskExecutionTest {
+public class ProjectLayoutFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
     @Test
     void projectLayout_not_injected_should_fix_and_inject() {
         testFix(
@@ -55,7 +55,7 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                     @TaskAction
                     final void action() {
                         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
-                        File buildDir = getProjectLayout().getBuildDirectory().file(".").get().getAsFile();
+                        File buildDir = getProjectLayout().getBuildDirectory().getAsFile().get();
                     }
                 }
             """);
@@ -109,7 +109,7 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                         getProjectLayout().getSettingsDirectory().file(IM_AT_THE_TOP_OF_THE_CLASS);
                         ProjectLayout projectLayout = getProjectLayout();
                         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
-                        File buildDir = getProjectLayout().getBuildDirectory().file(".").get().getAsFile();
+                        File buildDir = getProjectLayout().getBuildDirectory().getAsFile().get();
                     }
                 }
             """);
@@ -153,7 +153,7 @@ public class GetProjectGetProjectDirTest extends IllegalMethodCalledDuringTaskEx
                     final void action() {
                         ProjectLayout projectLayout = getProjectLayout();
                         File projectDir = getProjectLayout().getProjectDirectory().getAsFile();
-                        File buildDir = getProjectLayout().getBuildDirectory().file(".").get().getAsFile();
+                        File buildDir = getProjectLayout().getBuildDirectory().getAsFile().get();
                     }
                 }
             """);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

FLUP to https://github.com/palantir/gradle-guide/pull/213

We are rolling out the configuration cache. We are doing this [incrementally, one task at a time](https://github.com/palantir/gradle-incremental-configuration-cache). However, for incremental rollout to begin, [all configuration cache problems that occur in the configuration phase must be fixed](https://github.com/palantir/gradle-incremental-configuration-cache/pull/6). 

## After this PR

Autofix `getProject(). getLayout()` and `getProject().getBuildDir()` to CC-friendly methods.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Autofix `getProject().getLayout()` and `getProject().getBuildDir()`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

The fix for `getBuildDir()` is quite ugly, but I guess it just explicates the eagerness intrinsic in `Project::getBuildDir()`