### PR TITLE
Autofix `task.getProject().delete()` to a configuration cache friendly method.

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -106,6 +106,16 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .named("getProviders")
             .withNoParameters();
 
+    // This method is fixable
+    private static final Matcher<ExpressionTree> deleteAction = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("delete")
+            .withParameters("org.gradle.api.Action");
+
+    // This method is evil, and unfixabe
+    // https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#delete(java.lang.Object...)
+    private static final Matcher<ExpressionTree> deletePaths =
+            Matchers.instanceMethod().onDescendantOf("org.gradle.api.Project").named("delete");
     private static final TaskExecutionViolation REPORT_GET_PROJECT = TaskExecutionViolation.report(
             ChainedCallMatcher.of(getProject), "Don't call `getProject()` in task actions");
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_LOGGER = TaskExecutionViolation.fix(
@@ -138,6 +148,13 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             ChainedCallMatcher.of(getProject, exec),
             "Instead of `getProject().exec(...)`, do `ExecOperations#(...)`",
             GradleFix.onService(GradleService.EXEC_OPERATIONS, Replacement.template("exec(%s)")));
+    private static final TaskExecutionViolation FIX_GET_PROJECT_DELETE_ACTION = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, deleteAction),
+            "Instead of `getProject().delete(...)`, do `getFileSystemOperations().delete(...)`",
+            GradleFix.onService(GradleService.FILE_SYSTEMS_OPERATIONS, Replacement.template("delete(%s)")));
+    private static final TaskExecutionViolation REPORT_GET_PROJECT_DELETE_PATHS = TaskExecutionViolation.report(
+            ChainedCallMatcher.of(getProject, deletePaths),
+            "Instead of `getProject().delete(...)`, do `getFileSystemOperations().delete(...)`");
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_ROOT_DIR = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, getRootDir),
             "Instead of `getProject().getRootDir()`, do `getBuildLayout().getRootDirectory().getAsFile()`",
@@ -154,6 +171,7 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
     private static final List<TaskExecutionViolation> violationsInOrderOfSpecificity = Stream.of(
                     FIX_GET_PROJECT_TAR_TREE,
                     FIX_GET_PROJECT_EXEC,
+                    FIX_GET_PROJECT_DELETE_ACTION,
                     FIX_GET_PROJECT_PROVIDER,
                     FIX_GET_PROJECT_GET_PROVIDERS,
                     FIX_GET_PROJECT_COPY,
@@ -161,6 +179,7 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
                     FIX_GET_PROJECT_GET_PROJECT_DIR,
                     FIX_GET_PROJECT_GET_LAYOUT,
                     FIX_GET_PROJECT_GET_LOGGER,
+                    REPORT_GET_PROJECT_DELETE_PATHS,
                     FIX_GET_PROJECT_GET_ROOT_DIR,
                     REPORT_GET_PROJECT)
             .sorted()

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -24,6 +24,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.suppliers.Suppliers;
 import com.google.errorprone.util.ASTHelpers;
 import com.palantir.gradle.guide.errorprone.GradleGuideBugChecker;
 import com.palantir.gradle.guide.errorprone.types.GradleFix;
@@ -106,16 +107,15 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .named("getProviders")
             .withNoParameters();
 
-    // This method is fixable
     private static final Matcher<ExpressionTree> deleteAction = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Project")
             .named("delete")
             .withParameters("org.gradle.api.Action");
 
-    // This method is evil, and unfixabe
-    // https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#delete(java.lang.Object...)
-    private static final Matcher<ExpressionTree> deletePaths =
-            Matchers.instanceMethod().onDescendantOf("org.gradle.api.Project").named("delete");
+    private static final Matcher<ExpressionTree> deletePaths = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("delete")
+            .withParametersOfType(List.of(Suppliers.arrayOf(Suppliers.OBJECT_TYPE)));
     private static final TaskExecutionViolation REPORT_GET_PROJECT = TaskExecutionViolation.report(
             ChainedCallMatcher.of(getProject), "Don't call `getProject()` in task actions");
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_LOGGER = TaskExecutionViolation.fix(
@@ -152,9 +152,13 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             ChainedCallMatcher.of(getProject, deleteAction),
             "Instead of `getProject().delete(...)`, do `getFileSystemOperations().delete(...)`",
             GradleFix.onService(GradleService.FILE_SYSTEMS_OPERATIONS, Replacement.template("delete(%s)")));
-    private static final TaskExecutionViolation REPORT_GET_PROJECT_DELETE_PATHS = TaskExecutionViolation.report(
+    private static final TaskExecutionViolation REPORT_GET_PROJECT_DELETE_PATHS = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, deletePaths),
-            "Instead of `getProject().delete(...)`, do `getFileSystemOperations().delete(...)`");
+            "Instead of `getProject().delete(...)`, do `getFileSystemOperations().delete(...)`",
+            GradleFix.onService(
+                    GradleService.FILE_SYSTEMS_OPERATIONS,
+                    Replacement.template(
+                            "delete(deleteSpec -> deleteSpec.delete(%s).setFollowSymlinks(false)).getDidWork()")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_GET_ROOT_DIR = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, getRootDir),
             "Instead of `getProject().getRootDir()`, do `getBuildLayout().getRootDirectory().getAsFile()`",

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/FileSystemOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/FileSystemOperationsFixesTest.java
@@ -19,7 +19,7 @@ package com.palantir.gradle.guide.errorprone.taskexecution;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("LineLength")
-public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTest {
+public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
     @Test
     void projectLayout_not_injected_should_fix_and_inject() {
         testFix(
@@ -33,6 +33,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                 abstract class AlreadyAbstractTask extends DefaultTask {
                     @TaskAction
                     final void action() {
+                        getProject().delete(deleteSpec -> {
+                            deleteSpec.delete("delete");
+                        });
                         getProject().copy(copySpec -> {
                             copySpec.from("src");
                             copySpec.into("dest");
@@ -53,6 +56,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                     protected abstract FileSystemOperations getFileSystemOperations();
                     @TaskAction
                     final void action() {
+                        getFileSystemOperations().delete(deleteSpec -> {
+                            deleteSpec.delete("delete");
+                        });
                         getFileSystemOperations().copy(copySpec -> {
                             copySpec.from("src");
                             copySpec.into("dest");
@@ -80,7 +86,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                     protected abstract FileSystemOperations getFileSystemOperations();
                     @TaskAction
                     final void action() {
-                        getFileSystemOperations().delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getProject().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getProject().copy(copySpec -> {
                             copySpec.from("src");
                         });
@@ -101,7 +109,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                     protected abstract FileSystemOperations getFileSystemOperations();
                     @TaskAction
                     final void action() {
-                        getFileSystemOperations().delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getFileSystemOperations().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getFileSystemOperations().copy(copySpec -> {
                             copySpec.from("src");
                         });
@@ -129,10 +139,13 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
 
                     @TaskAction
                     final void action() {
-                        fsOps.delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getProject().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getProject().copy(copySpec -> {
                             copySpec.from("src");
                         });
+
                     }
                 }
                 """,
@@ -154,7 +167,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
 
                     @TaskAction
                     final void action() {
-                        fsOps.delete(deleteSpec -> deleteSpec.delete("temp"));
+                        fsOps.delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         fsOps.copy(copySpec -> {
                             copySpec.from("src");
                         });
@@ -178,7 +193,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                     protected abstract FileSystemOperations getFSOps();
                     @TaskAction
                     final void action() {
-                        getFSOps().delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getProject().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getProject().copy(copySpec -> {
                             copySpec.from("src");
                         });
@@ -199,7 +216,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                     protected abstract FileSystemOperations getFSOps();
                     @TaskAction
                     final void action() {
-                        getFSOps().delete(deleteSpec -> deleteSpec.delete("temp"));
+                        getFSOps().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getFSOps().copy(copySpec -> {
                             copySpec.from("src");
                         });
@@ -221,6 +240,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                 class ConcreteTask extends DefaultTask {
                     @TaskAction
                     final void action() {
+                        getProject().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getProject().copy(copySpec -> {
                             copySpec.from("input");
                             copySpec.into("output");
@@ -241,6 +263,9 @@ public class GetProjectCopyTest extends IllegalMethodCalledDuringTaskExecutionTe
                     protected abstract FileSystemOperations getFileSystemOperations();
                     @TaskAction
                     final void action() {
+                        getFileSystemOperations().delete(deleteSpec -> {
+                            deleteSpec.delete("temp");
+                        });
                         getFileSystemOperations().copy(copySpec -> {
                             copySpec.from("input");
                             copySpec.into("output");

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/FileSystemOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/FileSystemOperationsFixesTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("LineLength")
 public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
     @Test
-    void projectLayout_not_injected_should_fix_and_inject() {
+    void fileSystemOperations_not_injected_should_fix_and_inject() {
         testFix(
                 "AlreadyAbstractTask.java",
                 """
@@ -33,13 +33,19 @@ public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTask
                 abstract class AlreadyAbstractTask extends DefaultTask {
                     @TaskAction
                     final void action() {
-                        getProject().delete(deleteSpec -> {
-                            deleteSpec.delete("delete");
-                        });
                         getProject().copy(copySpec -> {
                             copySpec.from("src");
                             copySpec.into("dest");
                         });
+
+                        // delete with deleteSpec
+                        getProject().delete(deleteSpec -> {
+                            deleteSpec.delete("delete");
+                        });
+
+                        // delete with varargs
+                        getProject().delete("happy");
+                        boolean deleted = getProject().delete("happy", "squirrel");
                     }
                 }
                 """,
@@ -56,18 +62,25 @@ public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTask
                     protected abstract FileSystemOperations getFileSystemOperations();
                     @TaskAction
                     final void action() {
-                        getFileSystemOperations().delete(deleteSpec -> {
-                            deleteSpec.delete("delete");
-                        });
                         getFileSystemOperations().copy(copySpec -> {
                             copySpec.from("src");
                             copySpec.into("dest");
                         });
+
+                        // delete with deleteSpec
+                        getFileSystemOperations().delete(deleteSpec -> {
+                            deleteSpec.delete("delete");
+                        });
+
+                        // delete with varargs
+                        getFileSystemOperations().delete(deleteSpec -> deleteSpec.delete("happy").setFollowSymlinks(false)).getDidWork();
+                        boolean deleted = getFileSystemOperations().delete(deleteSpec -> deleteSpec.delete("happy", "squirrel").setFollowSymlinks(false)).getDidWork();
                     }
                 }
                 """);
     }
 
+    @SuppressWarnings("MethodLength")
     @Test
     void fileSystemOperations_already_injected_should_fix_without_injecting_again() {
         testFix(
@@ -276,7 +289,7 @@ public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTask
     }
 
     @Test
-    void transitive_calls_to_getProject_copy_should_fail_in_taskActions() {
+    void transitive_calls_to_getProject_copy_should_fail_in_taskactions() {
         test(
                 """
                 import org.gradle.api.Action;

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ReportUnfixableViolationsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ReportUnfixableViolationsTest.java
@@ -18,7 +18,7 @@ package com.palantir.gradle.guide.errorprone.taskexecution;
 
 import org.junit.jupiter.api.Test;
 
-public class GetProjectTest extends IllegalMethodCalledDuringTaskExecutionTest {
+public class ReportUnfixableViolationsTest extends IllegalMethodCalledDuringTaskExecutionTest {
     @Test
     void getProject_within_TaskAction_should_fail() {
         test(
@@ -36,6 +36,25 @@ public class GetProjectTest extends IllegalMethodCalledDuringTaskExecutionTest {
 
                     // BUG: Diagnostic contains: Don't call `getProject()` in task actions
                     String projectPath = getProject().getPath();
+                }
+            }
+        """);
+    }
+
+    @Test
+    void getProject_delete_within_TaskAction_should_fail() {
+        test(
+                """
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.tasks.TaskAction;
+
+            abstract class CustomTask extends DefaultTask {
+                @TaskAction
+                final void action() {
+                    // BUG: Diagnostic contains: Instead of `getProject().delete(...)`, do `getFileSystemOperations().delete(...)`
+                    getProject().delete("myfile");
                 }
             }
         """);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are rolling out the configuration cache. We are doing this [incrementally, one task at a time](https://github.com/palantir/gradle-incremental-configuration-cache). However, for incremental rollout to begin, [all configuration cache problems that occur in the configuration phase must be fixed](https://github.com/palantir/gradle-incremental-configuration-cache/pull/6). 

## After this PR

Autofix `task.getProject().delete()` to a CC-friendly method.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Autofix `task.getProject().delete()` to a configuration cache friendly method.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

