### PR TITLE
Autofix `task.getProject().tarTree(...)` to a configuration cache friendly method.

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -85,6 +85,10 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .onDescendantOf("org.gradle.api.Project")
             .named("copy")
             .withParameters("org.gradle.api.Action");
+    private static final Matcher<ExpressionTree> tarTree = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("tarTree")
+            .withParameters("java.lang.Object");
     private static final Matcher<ExpressionTree> exec = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Project")
             .named("exec")
@@ -122,6 +126,10 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             ChainedCallMatcher.of(getProject, copy),
             "Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`",
             GradleFix.onService(GradleService.FILE_SYSTEMS_OPERATIONS, Replacement.template("copy(%s)")));
+    private static final TaskExecutionViolation FIX_GET_PROJECT_TAR_TREE = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, tarTree),
+            "Instead of `getProject().tarTree(...)`, do `ArchiveOperations#tarTree`",
+            GradleFix.onService(GradleService.ARCHIVE_OPERATIONS, Replacement.template("tarTree(%s)")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_EXEC = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, exec),
             "Instead of `getProject().exec(...)`, do `ExecOperations#(...)`",
@@ -136,6 +144,7 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             GradleFix.onService(GradleService.PROVIDER_FACTORY, Replacement.literal("")));
 
     private static final List<TaskExecutionViolation> violationsInOrderOfSpecificity = Stream.of(
+                    FIX_GET_PROJECT_TAR_TREE,
                     FIX_GET_PROJECT_EXEC,
                     FIX_GET_PROJECT_PROVIDER,
                     FIX_GET_PROJECT_GET_PROVIDERS,

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
@@ -27,8 +27,9 @@ import com.sun.tools.javac.code.Type;
 public enum GradleService {
     BUILD_LAYOUT("org.gradle.api.file.BuildLayout", "getBuildLayout"),
     PROJECT_LAYOUT("org.gradle.api.file.ProjectLayout", "getProjectLayout"),
-    PROVIDER_FACTORY("org.gradle.api.provider.ProviderFactory", "getProviderFactory"),
     FILE_SYSTEMS_OPERATIONS("org.gradle.api.file.FileSystemOperations", "getFileSystemOperations"),
+    ARCHIVE_OPERATIONS("org.gradle.api.file.ArchiveOperations", "getArchiveOperations"),
+    PROVIDER_FACTORY("org.gradle.api.provider.ProviderFactory", "getProviderFactory"),
     EXEC_OPERATIONS("org.gradle.process.ExecOperations", "getExecOperations");
 
     private final Supplier<Type> type;

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ArchiveOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ArchiveOperationsFixesTest.java
@@ -1,0 +1,250 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.taskexecution;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("LineLength")
+public class ArchiveOperationsFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
+    @Test
+    void archiveOperations_not_injected_should_fix_and_inject() {
+        testFix(
+                "AlreadyAbstractTask.java",
+                """
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyAbstractTask extends DefaultTask {
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getProject().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """,
+                """
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyAbstractTask extends DefaultTask {
+                    @Inject
+                    protected abstract ArchiveOperations getArchiveOperations();
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getArchiveOperations().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void archiveOperations_already_injected_should_fix_without_injecting_again() {
+        testFix(
+                "AlreadyInjectedTask.java",
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    @Inject
+                    protected abstract ArchiveOperations getArchiveOperations();
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getProject().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    @Inject
+                    protected abstract ArchiveOperations getArchiveOperations();
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getArchiveOperations().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """);
+
+        testFix(
+                "AlreadyInjectedTask.java",
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    private final ArchiveOperations archiveOps;
+
+                    AlreadyInjectedTask(ArchiveOperations archiveOps) {
+                        this.archiveOps = archiveOps;
+                    }
+
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getProject().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    private final ArchiveOperations archiveOps;
+
+                    AlreadyInjectedTask(ArchiveOperations archiveOps) {
+                        this.archiveOps = archiveOps;
+                    }
+
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = archiveOps.tarTree("happy-squirrel.tar");
+                    }
+                }
+                """);
+
+        testFix(
+                "AlreadyInjectedTask.java",
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    @Inject
+                    protected abstract ArchiveOperations getArchiveOps();
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getProject().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class AlreadyInjectedTask extends DefaultTask {
+                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
+                    @Inject
+                    protected abstract ArchiveOperations getArchiveOps();
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getArchiveOps().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void concrete_task_should_fix() {
+        testFix(
+                "ConcreteTask.java",
+                """
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                class ConcreteTask extends DefaultTask {
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getProject().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """,
+                """
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.file.ArchiveOperations;
+                import org.gradle.api.file.FileTree;
+                import org.gradle.api.tasks.TaskAction;
+                abstract class ConcreteTask extends DefaultTask {
+                    @Inject
+                    protected abstract ArchiveOperations getArchiveOperations();
+                    @TaskAction
+                    final void action() {
+                        FileTree fileTree = getArchiveOperations().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """);
+    }
+
+    @Test
+    void transitive_calls_to_getProject_copy_should_fail_in_taskActions() {
+        test(
+                """
+                import org.gradle.api.Action;
+                import org.gradle.api.Task;
+                abstract class CustomTaskAction implements Action<Task> {
+                    @Override
+                    public void execute(Task task) {
+                        // BUG: Diagnostic contains: Instead of `getProject().tarTree(...)`, do `getArchiveOperations().tarTree(...)`
+                        task.getProject().tarTree("happy-squirrel.tar");
+                        bad_helper(task);
+                    }
+                    public void bad_helper(Task task) {
+                        System.out.println("I am a happy squirrel");
+                        // BUG: Diagnostic contains: Instead of `getProject().tarTree(...)`, do `getArchiveOperations().tarTree(...)`
+                        task.getProject().tarTree("happy-squirrel.tar");
+                    }
+                }
+                """);
+    }
+}

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ArchiveOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ArchiveOperationsFixesTest.java
@@ -235,13 +235,13 @@ public class ArchiveOperationsFixesTest extends IllegalMethodCalledDuringTaskExe
                 abstract class CustomTaskAction implements Action<Task> {
                     @Override
                     public void execute(Task task) {
-                        // BUG: Diagnostic contains: Instead of `getProject().tarTree(...)`, do `getArchiveOperations().tarTree(...)`
+                        // BUG: Diagnostic contains: Instead of `getProject().tarTree(...)`, do `ArchiveOperations#tarTree`
                         task.getProject().tarTree("happy-squirrel.tar");
                         bad_helper(task);
                     }
                     public void bad_helper(Task task) {
                         System.out.println("I am a happy squirrel");
-                        // BUG: Diagnostic contains: Instead of `getProject().tarTree(...)`, do `getArchiveOperations().tarTree(...)`
+                        // BUG: Diagnostic contains: Instead of `getProject().tarTree(...)`, do `ArchiveOperations#tarTree`
                         task.getProject().tarTree("happy-squirrel.tar");
                     }
                 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are rolling out the configuration cache. We are doing this [incrementally, one task at a time](https://github.com/palantir/gradle-incremental-configuration-cache). However, for incremental rollout to begin, [all configuration cache problems that occur in the configuration phase must be fixed](https://github.com/palantir/gradle-incremental-configuration-cache/pull/6). 

## After this PR

Autofix `task.getProject().tarTree(...)` to a CC-friendly method.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Autofix `task.getProject().tarTree(...)` to a configuration cache friendly method.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

