### PR TITLE
Autofix `getProject().getObjects()` to `getObjectFactory()`

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -90,6 +90,10 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .onDescendantOf("org.gradle.api.Project")
             .named("copy")
             .withParameters("org.gradle.api.Action");
+    private static final Matcher<ExpressionTree> getObjects = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("getObjects")
+            .withNoParameters();
     private static final Matcher<ExpressionTree> tarTree = Matchers.instanceMethod()
             .onDescendantOf("org.gradle.api.Project")
             .named("tarTree")
@@ -140,6 +144,10 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             ChainedCallMatcher.of(getProject, copy),
             "Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`",
             GradleFix.onService(GradleService.FILE_SYSTEMS_OPERATIONS, Replacement.template("copy(%s)")));
+    private static final TaskExecutionViolation FIX_GET_PROJECT_GET_OBJECT = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, getObjects),
+            "Instead of `getProject().getObject()`, do `getObjectFactory()`",
+            GradleFix.onService(GradleService.OBJECT_FACTORY, Replacement.literal("")));
     private static final TaskExecutionViolation FIX_GET_PROJECT_TAR_TREE = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, tarTree),
             "Instead of `getProject().tarTree(...)`, do `ArchiveOperations#tarTree`",
@@ -173,6 +181,7 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             GradleFix.onService(GradleService.PROVIDER_FACTORY, Replacement.literal("")));
 
     private static final List<TaskExecutionViolation> violationsInOrderOfSpecificity = Stream.of(
+                    FIX_GET_PROJECT_GET_OBJECT,
                     FIX_GET_PROJECT_TAR_TREE,
                     FIX_GET_PROJECT_EXEC,
                     FIX_GET_PROJECT_DELETE_ACTION,

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
@@ -28,6 +28,7 @@ public enum GradleService {
     BUILD_LAYOUT("org.gradle.api.file.BuildLayout", "getBuildLayout"),
     PROJECT_LAYOUT("org.gradle.api.file.ProjectLayout", "getProjectLayout"),
     FILE_SYSTEMS_OPERATIONS("org.gradle.api.file.FileSystemOperations", "getFileSystemOperations"),
+    OBJECT_FACTORY("org.gradle.api.model.ObjectFactory", "getObjectFactory"),
     ARCHIVE_OPERATIONS("org.gradle.api.file.ArchiveOperations", "getArchiveOperations"),
     PROVIDER_FACTORY("org.gradle.api.provider.ProviderFactory", "getProviderFactory"),
     EXEC_OPERATIONS("org.gradle.process.ExecOperations", "getExecOperations");

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ObjectFactoryFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ObjectFactoryFixesTest.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.taskexecution;
+
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class ObjectFactoryFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
+    @Test
+    void should_fix() {
+        testFix(
+                "CustomTask.java",
+                """
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.tasks.TaskAction;
+            import org.gradle.api.logging.Logger;
+
+            abstract class CustomTask extends DefaultTask {
+                @TaskAction
+                final void action() {
+                    getProject().getObjects().setProperty(String.class);
+                }
+            }
+        """,
+                """
+            import javax.inject.Inject;
+            import org.gradle.api.DefaultTask;
+            import org.gradle.api.logging.Logger;
+            import org.gradle.api.model.ObjectFactory;
+            import org.gradle.api.tasks.TaskAction;
+
+            abstract class CustomTask extends DefaultTask {
+                @Inject
+                protected abstract ObjectFactory getObjectFactory();
+                @TaskAction
+                final void action() {
+                    getObjectFactory().setProperty(String.class);
+                }
+            }
+        """);
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are rolling out the configuration cache. We are doing this [incrementally, one task at a time](https://github.com/palantir/gradle-incremental-configuration-cache). However, for incremental rollout to begin, [all configuration cache problems that occur in the configuration phase must be fixed](https://github.com/palantir/gradle-incremental-configuration-cache/pull/6). 

## After this PR

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Autofix `getProject().getObjects()` to `getObjectFactory()` 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
