### PR TITLE
Autofix `getProject().exec(...)` to `getExecOperations().exec(...)`

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -77,6 +77,10 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             .onDescendantOf("org.gradle.api.Project")
             .named("copy")
             .withParameters("org.gradle.api.Action");
+    private static final Matcher<ExpressionTree> exec = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.Project")
+            .named("exec")
+            .withParameters("org.gradle.api.Action");
 
     private static final TaskExecutionViolation REPORT_GET_PROJECT = TaskExecutionViolation.report(
             ChainedCallMatcher.of(getProject), "Don't call `getProject()` in task actions");
@@ -94,8 +98,13 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
             ChainedCallMatcher.of(getProject, copy),
             "Instead of `getProject().copy(...)`, do `getFileSystemOperations().copy(...)`",
             GradleFix.onService(GradleService.FILE_SYSTEMS_OPERATIONS, Replacement.template("copy(%s)")));
+    private static final TaskExecutionViolation FIX_GET_PROJECT_EXEC = TaskExecutionViolation.fix(
+            ChainedCallMatcher.of(getProject, exec),
+            "Instead of `getProject().exec(...)`, do `ExecOperations#(...)`",
+            GradleFix.onService(GradleService.EXEC_OPERATIONS, Replacement.template("exec(%s)")));
 
     private static final List<TaskExecutionViolation> violationsInOrderOfSpecificity = Stream.of(
+                    FIX_GET_PROJECT_EXEC,
                     FIX_GET_PROJECT_COPY,
                     FIX_GET_PROJECT_GET_PROJECT_DIR,
                     FIX_GET_PROJECT_GET_LOGGER,

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
@@ -27,7 +27,8 @@ import com.sun.tools.javac.code.Type;
 public enum GradleService {
     BUILD_LAYOUT("org.gradle.api.file.BuildLayout", "getBuildLayout"),
     PROJECT_LAYOUT("org.gradle.api.file.ProjectLayout", "getProjectLayout"),
-    FILE_SYSTEMS_OPERATIONS("org.gradle.api.file.FileSystemOperations", "getFileSystemOperations");
+    FILE_SYSTEMS_OPERATIONS("org.gradle.api.file.FileSystemOperations", "getFileSystemOperations"),
+    EXEC_OPERATIONS("org.gradle.process.ExecOperations", "getExecOperations");
 
     private final Supplier<Type> type;
     private final String fullyQualifiedName;

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ExecOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ExecOperationsFixesTest.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.taskexecution;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("LineLength")
+public class ExecOperationsFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
+    @Test
+    void should_fix() {
+        testFix(
+                "ConcreteTask.java",
+                """
+                import java.io.File;
+                import java.util.List;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.tasks.TaskAction;
+                class ConcreteTask extends DefaultTask {
+                    @TaskAction
+                    final void action() {
+                        getProject().exec(execSpec -> {
+                            execSpec.setCommandLine(List.of("cat", "happy-squirrel.txt"));
+                        });
+                    }
+                }
+                """,
+                """
+                import java.io.File;
+                import java.util.List;
+                import javax.inject.Inject;
+                import org.gradle.api.DefaultTask;
+                import org.gradle.api.Plugin;
+                import org.gradle.api.Project;
+                import org.gradle.api.tasks.TaskAction;
+                import org.gradle.process.ExecOperations;
+                abstract class ConcreteTask extends DefaultTask {
+                    @Inject
+                    protected abstract ExecOperations getExecOperations();
+                    @TaskAction
+                    final void action() {
+                        getExecOperations().exec(execSpec -> {
+                            execSpec.setCommandLine(List.of("cat", "happy-squirrel.txt"));
+                        });
+                    }
+                }
+                """);
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We are rolling out the configuration cache. We are doing this [incrementally, one task at a time](https://github.com/palantir/gradle-incremental-configuration-cache). However, for incremental rollout to begin, [all configuration cache problems that occur in the configuration phase must be fixed](https://github.com/palantir/gradle-incremental-configuration-cache/pull/6). 

## After this PR

Autofix `getProject().exec(...)` to `getExecOperations().exec(...)`

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Autofix `getProject().exec(...)` to `getExecOperations().exec(...)`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
