### PR TITLE
Remove autofix which injects `BuildLayout`

### DIFF
--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/taskexecution/IllegalMethodCalledDuringTaskExecution.java
@@ -167,10 +167,9 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
                     GradleService.FILE_SYSTEMS_OPERATIONS,
                     Replacement.template(
                             "delete(deleteSpec -> deleteSpec.delete(%s).setFollowSymlinks(false)).getDidWork()")));
-    private static final TaskExecutionViolation FIX_GET_PROJECT_GET_ROOT_DIR = TaskExecutionViolation.fix(
+    private static final TaskExecutionViolation REPORT_GET_PROJECT_GET_ROOT_DIR = TaskExecutionViolation.report(
             ChainedCallMatcher.of(getProject, getRootDir),
-            "Instead of `getProject().getRootDir()`, do `getBuildLayout().getRootDirectory().getAsFile()`",
-            GradleFix.onService(GradleService.BUILD_LAYOUT, Replacement.literal("getRootDirectory().getAsFile()")));
+            "Instead of `getProject().getRootDir()`, the task should take the root directory as a task input");
     private static final TaskExecutionViolation FIX_GET_PROJECT_PROVIDER = TaskExecutionViolation.fix(
             ChainedCallMatcher.of(getProject, provider),
             "Instead of `getProject().provider(...)`, do `ProviderFactory#provider(...)`",
@@ -193,7 +192,7 @@ public final class IllegalMethodCalledDuringTaskExecution extends GradleGuideBug
                     FIX_GET_PROJECT_GET_LAYOUT,
                     FIX_GET_PROJECT_GET_LOGGER,
                     REPORT_GET_PROJECT_DELETE_PATHS,
-                    FIX_GET_PROJECT_GET_ROOT_DIR,
+                    REPORT_GET_PROJECT_GET_ROOT_DIR,
                     REPORT_GET_PROJECT)
             .sorted()
             .toList();

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/types/GradleService.java
@@ -25,7 +25,6 @@ import com.sun.tools.javac.code.Type;
  */
 @SuppressWarnings("ImmutableEnumChecker")
 public enum GradleService {
-    BUILD_LAYOUT("org.gradle.api.file.BuildLayout", "getBuildLayout"),
     PROJECT_LAYOUT("org.gradle.api.file.ProjectLayout", "getProjectLayout"),
     FILE_SYSTEMS_OPERATIONS("org.gradle.api.file.FileSystemOperations", "getFileSystemOperations"),
     OBJECT_FACTORY("org.gradle.api.model.ObjectFactory", "getObjectFactory"),

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/BuildLayoutFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/BuildLayoutFixesTest.java
@@ -22,27 +22,26 @@ import org.junit.jupiter.api.Test;
 public class BuildLayoutFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
     @Test
     void transitive_calls_to_violations_should_fail_in_taskActions() {
-        test(
-                """
-        import org.gradle.api.Action;
-        import org.gradle.api.Task;
-        import java.io.File;
+        test("""
+            import org.gradle.api.Action;
+            import org.gradle.api.Task;
+            import java.io.File;
 
 
-        abstract class CustomTaskAction implements Action<Task> {
-            @Override
-            public void execute(Task task) {
-                // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, the task should take the root directory as a task input
-                File rootDir = task.getProject().getRootDir();
-                bad_helper(task);
+            abstract class CustomTaskAction implements Action<Task> {
+                @Override
+                public void execute(Task task) {
+                    // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, the task should take the root directory as a task input
+                    File rootDir = task.getProject().getRootDir();
+                    bad_helper(task);
+                }
+
+                public void bad_helper(Task task) {
+                    System.out.println("I am a happy squirrel");
+                    // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, the task should take the root directory as a task input
+                    File rootDir = task.getProject().getRootDir();
+                }
             }
-
-            public void bad_helper(Task task) {
-                System.out.println("I am a happy squirrel");
-                // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, the task should take the root directory as a task input
-                File rootDir = task.getProject().getRootDir();
-            }
-        }
-        """);
+            """);
     }
 }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/BuildLayoutFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/BuildLayoutFixesTest.java
@@ -21,134 +21,6 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("LineLength")
 public class BuildLayoutFixesTest extends IllegalMethodCalledDuringTaskExecutionTest {
     @Test
-    void buildLayout_not_injected_should_fix_and_inject() {
-        testFix(
-                "AlreadyAbstractTask.java",
-                """
-                import java.io.File;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class AlreadyAbstractTask extends DefaultTask {
-                    @TaskAction
-                    final void action() {
-                        File rootDir = getProject().getRootDir();
-                    }
-                }
-            """,
-                """
-                import java.io.File;
-                import javax.inject.Inject;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.file.BuildLayout;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class AlreadyAbstractTask extends DefaultTask {
-                    @Inject
-                    protected abstract BuildLayout getBuildLayout();
-
-                    @TaskAction
-                    final void action() {
-                        File rootDir = getBuildLayout().getRootDirectory().getAsFile();
-                    }
-                }
-            """);
-    }
-
-    @Test
-    void buildLayout_already_injected_should_fix_without_injecting_again() {
-        testFix(
-                "AlreadyInjectedTask.java",
-                """
-                import java.io.File;
-                import javax.inject.Inject;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.file.BuildLayout;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class AlreadyInjectedTask extends DefaultTask {
-                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
-
-                    @Inject
-                    protected abstract BuildLayout getBuildLayout();
-
-                    @TaskAction
-                    final void action() {
-                        getBuildLayout().getSettingsDirectory().file(IM_AT_THE_TOP_OF_THE_CLASS);
-                        File rootDir = getProject().getRootDir();
-                    }
-                }
-            """,
-                """
-                import java.io.File;
-                import javax.inject.Inject;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.file.BuildLayout;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class AlreadyInjectedTask extends DefaultTask {
-                    private static final String IM_AT_THE_TOP_OF_THE_CLASS = "happy_squirrel.txt";
-
-                    @Inject
-                    protected abstract BuildLayout getBuildLayout();
-
-                    @TaskAction
-                    final void action() {
-                        getBuildLayout().getSettingsDirectory().file(IM_AT_THE_TOP_OF_THE_CLASS);
-                        File rootDir = getBuildLayout().getRootDirectory().getAsFile();
-                    }
-                }
-            """);
-    }
-
-    @Test
-    void concrete_task_should_fix() {
-        testFix(
-                "ConcreteTask.java",
-                """
-                import java.io.File;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.tasks.TaskAction;
-
-                class ConcreteTask extends DefaultTask {
-                    @TaskAction
-                    final void action() {
-                        File rootDir = getProject().getRootDir();
-                    }
-                }
-            """,
-                """
-                import java.io.File;
-                import javax.inject.Inject;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.file.BuildLayout;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class ConcreteTask extends DefaultTask {
-                    @Inject
-                    protected abstract BuildLayout getBuildLayout();
-
-                    @TaskAction
-                    final void action() {
-                        File rootDir = getBuildLayout().getRootDirectory().getAsFile();
-                    }
-                }
-            """);
-    }
-
-    @Test
     void transitive_calls_to_violations_should_fail_in_taskActions() {
         test(
                 """
@@ -160,61 +32,17 @@ public class BuildLayoutFixesTest extends IllegalMethodCalledDuringTaskExecution
         abstract class CustomTaskAction implements Action<Task> {
             @Override
             public void execute(Task task) {
-                // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, do `getBuildLayout().getRootDirectory().getAsFile()`
+                // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, the task should take the root directory as a task input
                 File rootDir = task.getProject().getRootDir();
                 bad_helper(task);
             }
 
             public void bad_helper(Task task) {
                 System.out.println("I am a happy squirrel");
-                // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, do `getBuildLayout().getRootDirectory().getAsFile()`
+                // BUG: Diagnostic contains: Instead of `getProject().getRootDir()`, the task should take the root directory as a task input
                 File rootDir = task.getProject().getRootDir();
             }
         }
         """);
-
-        testFix(
-                "AlreadyAbstractTask.java",
-                """
-                import java.io.File;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class AlreadyAbstractTask extends DefaultTask {
-                    @TaskAction
-                    final void action() {
-                        helper();
-                    }
-
-                    private void helper() {
-                        File rootDir = getProject().getRootDir();
-                    }
-                }
-            """,
-                """
-                import java.io.File;
-                import javax.inject.Inject;
-                import org.gradle.api.DefaultTask;
-                import org.gradle.api.Plugin;
-                import org.gradle.api.Project;
-                import org.gradle.api.file.BuildLayout;
-                import org.gradle.api.tasks.TaskAction;
-
-                abstract class AlreadyAbstractTask extends DefaultTask {
-                    @Inject
-                    protected abstract BuildLayout getBuildLayout();
-
-                    @TaskAction
-                    final void action() {
-                        helper();
-                    }
-
-                    private void helper() {
-                        File rootDir = getBuildLayout().getRootDirectory().getAsFile();
-                    }
-                }
-            """);
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

In https://github.com/palantir/gradle-guide/pull/241 we introduced an autofix which involved injecting [BuildLayout](https://docs.gradle.org/current/dsl/org.gradle.api.file.BuildLayout.html) into tasks. BuildLayout has the Settings service scope, and is unavailable in tasks. This causes the task being injected to fail at runtime.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Remove autofix which injects `BuildLayout`
==COMMIT_MSG==
Remove autofix which injects `BuildLayout`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

We could inject `org.greadle.initialization.layout.BuildLayout`instead, but it's internal.