### PR TITLE
Add `UseGradleLoggerInGradlePlugins` to stop people from using `SafeLogger` or generic slf4j `Logger`s within Gradle plugins

### DIFF
--- a/errorprones.md
+++ b/errorprones.md
@@ -142,5 +142,21 @@ encourage you to do so sparingly, and think about whether something can be impro
 
 </td>
 </tr>
+
+<tr>
+<td>
+
+<a id="UseGradleLoggerInGradlePlugins" href="guide/anatomy-of-a-gradle-plugin.md#plugins">`UseGradleLoggerInGradlePlugins`</a>
+
+</td>
+<td>
+<a href="guide/anatomy-of-a-gradle-plugin.md#plugins">Please read</a>
+</td>
+<td>
+
+Use Gradle's `Logger` instead of `SafeLogger` within Gradle plugins. Safe logging isn't necessary for Gradle plugins which don't process sensitive data.
+
+</td>
+</tr>
 </tbody>
 </table>

--- a/gradle-guide-error-prone/build.gradle
+++ b/gradle-guide-error-prone/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.google.errorprone:error_prone_test_helpers'
+    testImplementation 'com.palantir.safe-logging:logger'
     testImplementation gradleApi()
 }
 
@@ -36,4 +37,8 @@ moduleJvmArgs {
         'jdk.compiler/com.sun.tools.javac.util'
     ]
     opens = ['jdk.compiler/com.sun.tools.javac.comp']
+}
+
+checkUnusedDependencies {
+    ignore('com.palantir.safe-logging', 'logger')  // Used within a test fixture
 }

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/UseGradleLoggerInGradlePlugins.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/UseGradleLoggerInGradlePlugins.java
@@ -1,0 +1,99 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.VariableTree;
+import java.util.Optional;
+import javax.lang.model.element.Modifier;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        severity = SeverityLevel.ERROR,
+        summary = "Use Gradle's `Logger` instead of `SafeLogger` within Gradle plugins. "
+                + "Safe logging isn't necessary for Gradle plugins which don't process sensitive data.")
+public final class UseGradleLoggerInGradlePlugins extends GradleGuideBugChecker
+        implements BugChecker.VariableTreeMatcher {
+    private static final Matcher<ClassTree> GRADLE_PLUGIN = Matchers.isSubtypeOf("org.gradle.api.Plugin");
+    private static final Matcher<VariableTree> SLF4J_LOGGER_IN_GRADLE_PLUGIN = Matchers.allOf(
+            Matchers.isField(),
+            Matchers.variableType(Matchers.allOf(
+                    Matchers.isSubtypeOf("org.slf4j.Logger"),
+                    Matchers.not(Matchers.isSubtypeOf("org.gradle.api.logging.Logger")))),
+            Matchers.enclosingClass(GRADLE_PLUGIN));
+    private static final Matcher<VariableTree> PRIVATE_STATIC_FINAL_SLF4J_LOGGER_IN_GRADLE_PLUGIN =
+            Matchers.allOf(SLF4J_LOGGER_IN_GRADLE_PLUGIN, Matchers.hasModifier(Modifier.PRIVATE));
+    private static final Matcher<VariableTree> SAFE_LOGGER_IN_GRADLE_PLUGIN = Matchers.allOf(
+            Matchers.isField(),
+            Matchers.variableType(Matchers.isSubtypeOf("com.palantir.logsafe.logger.SafeLogger")),
+            Matchers.enclosingClass(GRADLE_PLUGIN));
+
+    @Override
+    public Description matchVariable(VariableTree tree, VisitorState state) {
+        if (SAFE_LOGGER_IN_GRADLE_PLUGIN.matches(tree, state)) {
+            // Autofixing safe logging to Gradle logging is dangerous! Let the humans do it.
+            return buildDescription(tree).build();
+        } else if (PRIVATE_STATIC_FINAL_SLF4J_LOGGER_IN_GRADLE_PLUGIN.matches(tree, state)) {
+            SuggestedFix fix = SuggestedFix.builder()
+                    .merge(replaceWithGradleLogerDeclaration(tree, state))
+                    .build();
+            return buildDescription(tree).addFix(fix).build();
+        } else if (SLF4J_LOGGER_IN_GRADLE_PLUGIN.matches(tree, state)) {
+
+            return buildDescription(tree).build();
+        } else {
+            return Description.NO_MATCH;
+        }
+    }
+
+    private static SuggestedFix replaceWithGradleLogerDeclaration(VariableTree loggerDeclaration, VisitorState state) {
+        String loggerVarName = loggerDeclaration.getName().toString();
+        Optional<ClassTree> enclosingClass =
+                Optional.ofNullable(ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class));
+        if (enclosingClass.isEmpty()) {
+            throw new IllegalStateException("loggerDeclaration should always have an enclosing class");
+        }
+
+        String enclosingClassName = enclosingClass.get().getSimpleName().toString();
+        String gradleLoggerDeclaration = String.format(
+                "private static final Logger %s =" + " Logging.getLogger(%s.class);",
+                loggerVarName, enclosingClassName);
+
+        return SuggestedFix.builder()
+                .removeImport("org.slf4j.Logger")
+                .removeImport("org.slf4j.LoggerFactory")
+                .addImport("org.gradle.api.logging.Logger")
+                .addImport("org.gradle.api.logging.Logging")
+                .replace(loggerDeclaration, gradleLoggerDeclaration)
+                .build();
+    }
+
+    @Override
+    public MoreInfoLink moreInfoLink() {
+        return new MoreInfoHeadingLink("anatomy-of-a-gradle-plugin.md", "Plugins");
+    }
+}

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/UseGradleLoggerInGradlePluginsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/UseGradleLoggerInGradlePluginsTest.java
@@ -1,0 +1,102 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.guide.errorprone;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.palantir.gradle.guide.helpers.RefactoringValidator;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("MisformattedTestData")
+class UseGradleLoggerInGradlePluginsTest {
+    private final CompilationTestHelper compilationTestHelper =
+            CompilationTestHelper.newInstance(UseGradleLoggerInGradlePlugins.class, getClass());
+
+    @Test
+    void flag_safe_logger_instances() {
+        test("""
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import com.palantir.logsafe.logger.SafeLogger;
+            import com.palantir.logsafe.logger.SafeLoggerFactory;
+
+            abstract class MyProject implements Plugin<Project> {
+                // BUG: Diagnostic contains: Use Gradle's `Logger` instead of `SafeLogger` within Gradle plugins
+                private static final SafeLogger log = SafeLoggerFactory.get(MyProject.class);
+
+                @Override
+                public void apply(Project project) {}
+            }
+            """);
+    }
+
+    @Test
+    void autofix_slf4j_logger_instances() {
+        testFix("MyProject.java", """
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            abstract class MyProject implements Plugin<Project> {
+                private static final Logger log = LoggerFactory.getLogger(MyProject.class);
+
+                @Override
+                public void apply(Project project) {}
+            }
+            """, """
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.logging.Logger;
+            import org.gradle.api.logging.Logging;
+
+            abstract class MyProject implements Plugin<Project> {
+                private static final Logger log = Logging.getLogger(MyProject.class);
+
+                @Override
+                public void apply(Project project) {}
+            }
+            """);
+    }
+
+    @Test
+    void gradle_logger_instances_ok() {
+        test("""
+            import org.gradle.api.Plugin;
+            import org.gradle.api.Project;
+            import org.gradle.api.logging.Logger;
+            import org.gradle.api.logging.Logging;
+
+            abstract class MyProject implements Plugin<Project> {
+                private static final Logger log = Logging.getLogger(MyProject.class);
+
+                @Override
+                public void apply(Project project) {}
+            }
+            """);
+    }
+
+    private void testFix(String filename, @Language("Java") String before, @Language("Java") String after) {
+        RefactoringValidator.of(UseGradleLoggerInGradlePlugins.class, getClass())
+                .addInputLines(filename, before)
+                .addOutputLines(filename, after)
+                .doTest();
+    }
+
+    private void test(@Language("Java") String source) {
+        compilationTestHelper.addSourceLines("Test.java", source).doTest();
+    }
+}

--- a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
+++ b/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java
@@ -28,7 +28,8 @@ public class GradleGuidePlugin implements Plugin<Project> {
             "ConfigurationAvoidanceRegistration",
             "ProviderGet",
             "NonAbstractGradleType",
-            "IllegalMethodCalledDuringTaskExecution");
+            "IllegalMethodCalledDuringTaskExecution",
+            "UseGradleLoggerInGradlePlugins");
 
     @Override
     public final void apply(Project rootProject) {

--- a/guide/anatomy-of-a-gradle-plugin.md
+++ b/guide/anatomy-of-a-gradle-plugin.md
@@ -58,6 +58,11 @@ That's it! You have access to `Project`[^2] variable that allows you to create e
 
 [^2]: `Settings` instead if you make a setting plugin aka `Plugin<Settings>`.
 
+> [!NOTE]
+> You should use Gradle's [`Logger`](https://docs.gradle.org/current/javadoc/org/gradle/api/logging/Logger.html) within a Gradle plugin rather than other loggers.
+> The Gradle logger exposes the `lifecycle` log level, which always prints the log but does not colour it as a warn or error.
+> Also, the overhead of specialized loggers like [`SafeLogger`](https://github.com/palantir/safe-logging) aren't needed if the Gradle plugin is not processing sensitive information.
+
 ## Extensions
 
 Extensions are the way users can enter configuration for your Gradle plugin. We want to allow our users to set a `name`, looking something like:

--- a/versions.lock
+++ b/versions.lock
@@ -14,7 +14,7 @@ com.google.auto.value:auto-value-annotations:1.10.4 (2 constraints: 141da40a)
 
 com.google.errorprone:error_prone_annotation:2.41.0 (2 constraints: 9e2757d0)
 
-com.google.errorprone:error_prone_annotations:2.41.0 (6 constraints: d351c0d9)
+com.google.errorprone:error_prone_annotations:2.41.0 (9 constraints: fb7fc013)
 
 com.google.errorprone:error_prone_check_api:2.41.0 (2 constraints: c91921d6)
 
@@ -78,6 +78,14 @@ com.palantir.gradle.plugintesting:gradle-plugin-testing-junit:0.46.0 (1 constrai
 
 com.palantir.gradle.plugintesting:plugin-testing-core:0.46.0 (1 constraints: 3c05413b)
 
+com.palantir.safe-logging:logger:3.9.0 (1 constraints: 0e051536)
+
+com.palantir.safe-logging:logger-slf4j:3.9.0 (1 constraints: 070e6e42)
+
+com.palantir.safe-logging:logger-spi:3.9.0 (2 constraints: 1d1e0c7c)
+
+com.palantir.safe-logging:safe-logging:3.9.0 (2 constraints: 861d3e3e)
+
 commons-io:commons-io:2.19.0 (1 constraints: db190cdf)
 
 info.picocli:picocli:4.7.7 (1 constraints: 2816dcdd)
@@ -117,6 +125,8 @@ org.junit.platform:junit-platform-launcher:6.0.1 (2 constraints: 571b2362)
 org.objenesis:objenesis:2.4 (1 constraints: ea0c8c0a)
 
 org.opentest4j:opentest4j:1.3.0 (2 constraints: cf209249)
+
+org.slf4j:slf4j-api:1.7.31 (1 constraints: 471091b6)
 
 org.spockframework:spock-core:2.3-groovy-3.0 (3 constraints: 2c3deb38)
 

--- a/versions.props
+++ b/versions.props
@@ -4,6 +4,7 @@ com.google.errorprone:error_prone_* = 2.36.0
 com.google.guava:guava = 33.5.0-jre
 com.netflix.nebula:nebula-test = 10.6.2
 com.palantir.gradle.auto-parallelizable:* = 1.4.0
+com.palantir.safe-logging:* = 3.9.0
 com.palantir.suppressible-error-prone:* = 2.26.0
 net.ltgt.gradle:gradle-errorprone-plugin = 4.3.0
 org.junit.jupiter:* = 6.0.1


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

We should use Gradle's logger instead of SafeLogger in gradle 

- Gradle’s type exposes the lifecycle log level which will always print the log but does not colour it as a warn or error. Sometimes useful.
- [SafeLogger infra](https://github.com/palantir/safe-logging) outputs logs as json. This is very bad for Gradle as we have people reading the logs, not machines
- There is no need to have the overhead of safe vs unsafe args for our internal developments. Everything should be safe



## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Let's
- Autofix generic slf4j loggers to gradle loggers
- Flag SafeLogger usage. We don't autofix because the cost of autofixing somewhere we shouldn't is very large — logging sensitive information in an unsafe log.

==COMMIT_MSG==
Add `UseGradleLoggerInGradlePlugins` to stop people from using `SafeLogger` or generic slf4j `Logger`s within Gradle plugins
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

