### PR TITLE
Create `AvoidEagerApis` and surrounding infrastructure 

### DIFF
--- a/errorprones.md
+++ b/errorprones.md
@@ -12,6 +12,22 @@
 <tr>
 <td>
 
+<a id="AvoidEagerApis" href="guide/avoiding-unnecessary-configuration.md#lazy-task-registration">`AvoidEagerApis`</a>
+
+</td>
+<td>
+<a href="guide/avoiding-unnecessary-configuration.md#lazy-task-registration">Please read</a>
+</td>
+<td>
+
+Avoid eager API methods, which force tasks/configurations to be realized. 
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 <a id="ConfigurationAvoidanceRegistration" href="guide/avoiding-unnecessary-configuration.md#lazy-task-registration">`ConfigurationAvoidanceRegistration`</a>
 
 </td>

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleGuideBugChecker.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/GradleGuideBugChecker.java
@@ -32,7 +32,7 @@ public abstract class GradleGuideBugChecker extends BugChecker {
         return canonicalName();
     }
 
-    protected final boolean bestEffortModeEnabled(VisitorState state) {
+    protected static boolean bestEffortModeEnabled(VisitorState state) {
         return state.errorProneOptions()
                 .getFlags()
                 .getBoolean("GradleGuide:BestEffortMode")

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/AvoidEagerApis.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/AvoidEagerApis.java
@@ -1,0 +1,200 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.laziness;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.palantir.gradle.guide.errorprone.GradleGuideBugChecker;
+import com.palantir.gradle.guide.errorprone.utils.ChainedCallMatcher;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
+import java.util.List;
+import java.util.Map;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+        severity = SeverityLevel.ERROR,
+        summary = "Avoid eager API methods, which force tasks/configurations to be realized. ")
+public final class AvoidEagerApis extends GradleGuideBugChecker implements BugChecker.MethodInvocationTreeMatcher {
+    private static final Matcher<MethodInvocationTree> FIRST_ARGUMENT_IS_MAP =
+            Matchers.argument(0, Matchers.isSubtypeOf(Map.class));
+
+    private static final Matcher<MethodInvocationTree> SECOND_ARGUMENT_IS_GROOVY_CLOSURE =
+            Matchers.argument(1, Matchers.isSubtypeOf("groovy.lang.Closure"));
+
+    private static final Matcher<MethodInvocationTree> NO_DIRECT_REGISTER_EQUIVALENT =
+            Matchers.anyOf(FIRST_ARGUMENT_IS_MAP, SECOND_ARGUMENT_IS_GROOVY_CLOSURE);
+
+    private static final Matcher<ExpressionTree> CONTAINER_CREATE = Matchers.instanceMethod()
+            .onDescendantOfAny("org.gradle.api.NamedDomainObjectContainer")
+            .namedAnyOf("create");
+    private static final Matcher<ExpressionTree> CONTAINER_MAYBE_CREATE = Matchers.instanceMethod()
+            .onDescendantOfAny("org.gradle.api.NamedDomainObjectContainer")
+            .namedAnyOf("maybeCreate");
+    private static final Matcher<ExpressionTree> TASK_CONTAINER_GET_BY_PATH = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskContainer")
+            .namedAnyOf("getByPath");
+    private static final Matcher<ExpressionTree> TASK_CONTAINER_FIND_BY_PATH = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskContainer")
+            .namedAnyOf("findByPath");
+    private static final Matcher<ExpressionTree> TASK_CONTAINER_REPLACE = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskContainer")
+            .namedAnyOf("replace");
+    private static final Matcher<ExpressionTree> TASK_CONTAINER_GET_BY_NAME = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskContainer")
+            .namedAnyOf("getByName");
+    private static final Matcher<ExpressionTree> TASK_CONTAINER_FIND_BY_NAME = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskContainer")
+            .namedAnyOf("findByName");
+    private static final Matcher<ExpressionTree> COLLECTION_ALL = Matchers.instanceMethod()
+            .onDescendantOfAny("org.gradle.api.tasks.TaskCollection", "org.gradle.api.DomainObjectCollection")
+            .namedAnyOf("all");
+    private static final Matcher<ExpressionTree> TASK_COLLECTION_WHEN_TASK_ADDED = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskContainer")
+            .namedAnyOf("whenTaskAdded");
+    private static final Matcher<ExpressionTree> COLLECTION_WHEN_OBJECT_ADDED = Matchers.instanceMethod()
+            .onDescendantOfAny("org.gradle.api.DomainObjectCollection")
+            .namedAnyOf("whenObjectAdded");
+    private static final Matcher<ExpressionTree> COLLECTION_MATCHING = Matchers.instanceMethod()
+            .onDescendantOfAny("org.gradle.api.tasks.TaskCollection", "org.gradle.api.DomainObjectCollection")
+            .namedAnyOf("matching");
+    private static final Matcher<ExpressionTree> TASK_COLLECTION_GET_AT = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.tasks.TaskCollection")
+            .namedAnyOf("getAt");
+    private static final Matcher<ExpressionTree> COLLECTION_WITH_TYPE = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.DomainObjectCollection")
+            .namedAnyOf("withType");
+    private static final Matcher<ExpressionTree> SET_FIND_ALL = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.NamedDomainObjectSet")
+            .namedAnyOf("findAll");
+    private static final Matcher<ExpressionTree> COLLECTION_FIND_BY_NAME = Matchers.instanceMethod()
+            .onDescendantOf("org.gradle.api.NamedDomainObjectSet")
+            .namedAnyOf("findByName");
+
+    private static final List<EagerApiUsage> EAGER_API_USAGES = List.of(
+            EagerApiUsage.fix(
+                    ChainedCallMatcher.of(CONTAINER_CREATE),
+                    "Use `.register` instead",
+                    AvoidEagerApis::fixCreateToRegister),
+            EagerApiUsage.report(ChainedCallMatcher.of(CONTAINER_MAYBE_CREATE), "Use `.register` instead"),
+            EagerApiUsage.fix(
+                    ChainedCallMatcher.of(TASK_CONTAINER_GET_BY_NAME),
+                    "Use `.named(...)` instead of `.getByName(...)`",
+                    AvoidEagerApis::fixGetByNameToNamed),
+            EagerApiUsage.report( // fix
+                    ChainedCallMatcher.of(TASK_CONTAINER_FIND_BY_NAME),
+                    "Use `.named(...)` instead of `.findByName(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(TASK_CONTAINER_GET_BY_PATH),
+                    "Use `.named(...)` instead of `.getByPath(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(TASK_CONTAINER_FIND_BY_PATH),
+                    "Use `.named(...)` instead of `.findByPath(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(TASK_CONTAINER_REPLACE),
+                    "Avoid `.replace()` - forces eager resolution and behavior may change"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(TASK_COLLECTION_WHEN_TASK_ADDED),
+                    "Use `.configureEach(...)` instead of `.whenTaskAdded(...)`"),
+            EagerApiUsage.report( // fix
+                    ChainedCallMatcher.of(COLLECTION_MATCHING),
+                    "Use `.configureEach(...)` with conditional logic instead of `.matching(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(TASK_COLLECTION_GET_AT), "Use `.named(...)` instead of `.getAt(...)`"),
+            EagerApiUsage.report( // fix
+                    ChainedCallMatcher.of(COLLECTION_WITH_TYPE),
+                    "Use `.named(...).configureEach(...)` instead of `.withType(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(COLLECTION_ALL), "Use `.configureEach(...)` instead of `.all(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(COLLECTION_WHEN_OBJECT_ADDED),
+                    "Use `.configureEach(...)` instead of `.whenObjectAdded(...)`"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(SET_FIND_ALL),
+                    "Use `.matching(...)` and `.configureEach(...)` instead of `.findAll()"),
+            EagerApiUsage.report(
+                    ChainedCallMatcher.of(COLLECTION_FIND_BY_NAME),
+                    "Use `.named()` to avoid eager configuration. Note that it fails if the task does not exist"));
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        EAGER_API_USAGES.stream()
+                .filter(usage -> usage.matches(tree, state))
+                .findFirst()
+                .ifPresent(eagerApiUsage -> eagerApiUsage.fixOrReport(tree, state, this));
+
+        return Description.NO_MATCH;
+    }
+
+    private static SuggestedFix fixGetByNameToNamed(MethodInvocationTree tree, VisitorState state) {
+        // If the second argument is a closure, there is no direct java equivalent
+        if (SECOND_ARGUMENT_IS_GROOVY_CLOSURE.matches(tree, state)) {
+            return SuggestedFix.emptyFix();
+        }
+
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+
+        Tree parentLeaf = state.getPath().getParentPath().getLeaf();
+        String everythingBeforeGetByName = state.getSourceForNode(ASTHelpers.getReceiver(tree.getMethodSelect()));
+        String name = state.getSourceForNode(tree.getArguments().get(0));
+
+        if (parentLeaf instanceof TypeCastTree castTree) {
+            // For example: MyTask myTask = (myTask) project.getTasks().named(...).get();
+            String args = name + ", " + state.getSourceForNode(castTree.getType()) + ".class";
+            fix.replace(parentLeaf, everythingBeforeGetByName + ".named(" + args + ").get()");
+        } else {
+            // For example: Task myTask = project.getTasks().named(...).get();
+            fix.replace(tree, everythingBeforeGetByName + ".named(" + name + ").get()");
+        }
+
+        return fix.build();
+    }
+
+    private static SuggestedFix fixCreateToRegister(MethodInvocationTree tree, VisitorState state) {
+        if (!bestEffortModeEnabled(state)) {
+            return SuggestedFix.emptyFix();
+        }
+
+        // If the first argument is a map, or second is a Closure, there isn't an equivalent
+        // `.register` method to move to (from Java code at least)
+        if (NO_DIRECT_REGISTER_EQUIVALENT.matches(tree, state)) {
+            return SuggestedFix.emptyFix();
+        }
+
+        SuggestedFix.Builder fix = SuggestedFix.builder();
+        fix.postfixWith(tree, ".get()");
+        fix.replace(
+                tree.getMethodSelect(),
+                state.getSourceForNode(ASTHelpers.getReceiver(tree.getMethodSelect())) + ".register");
+        return fix.build();
+    }
+
+    @Override
+    public MoreInfoLink moreInfoLink() {
+        return new MoreInfoHeadingLink("avoiding-unnecessary-configuration.md", "Lazy task registration");
+    }
+}

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/EagerApiUsage.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/EagerApiUsage.java
@@ -1,0 +1,56 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.laziness;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.palantir.gradle.guide.errorprone.utils.ChainedCallMatcher;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Optional;
+
+/**
+ * Represents strategies to report or auto-fix illegal methods and methods chained to it.
+ */
+public record EagerApiUsage(ChainedCallMatcher violationMatcher, String message, Optional<FixFactory> fix) {
+    public static EagerApiUsage fix(ChainedCallMatcher violationMatcher, String messag, FixFactory fix) {
+        return new EagerApiUsage(violationMatcher, messag, Optional.of(fix));
+    }
+
+    public static EagerApiUsage report(ChainedCallMatcher violationMatcher, String message) {
+        return new EagerApiUsage(violationMatcher, message, Optional.empty());
+    }
+
+    public boolean matches(MethodInvocationTree call, VisitorState state) {
+        return violationMatcher.matches(call, state);
+    }
+
+    /**
+     * Returns {@code true} if a fix or report was done for {@code illegalCall}.
+     * Note that this is called on every method invocation, so performance matters.
+     */
+    public void fixOrReport(MethodInvocationTree illegalCall, VisitorState state, BugChecker bugChecker) {
+        Description.Builder descriptionBuilder =
+                bugChecker.buildDescription(illegalCall).setMessage(message);
+
+        SuggestedFix renderedFix =
+                fix.map(fixFactory -> fixFactory.construct(illegalCall, state)).orElseGet(SuggestedFix::emptyFix);
+
+        state.reportMatch(descriptionBuilder.addFix(renderedFix).build());
+    }
+}

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/FixFactory.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/FixFactory.java
@@ -1,0 +1,25 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.guide.errorprone.laziness;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.sun.source.tree.MethodInvocationTree;
+
+public interface FixFactory {
+    SuggestedFix construct(MethodInvocationTree tree, VisitorState state);
+}

--- a/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/ProviderImprovements.java
+++ b/gradle-guide-error-prone/src/main/java/com/palantir/gradle/guide/errorprone/laziness/ProviderImprovements.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.guide.errorprone.besteffort;
+package com.palantir.gradle.guide.errorprone.laziness;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/laziness/AvoidEagerApisTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/laziness/AvoidEagerApisTest.java
@@ -1,0 +1,478 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.guide.laziness;
+
+import com.google.errorprone.CompilationTestHelper;
+import com.palantir.gradle.guide.errorprone.laziness.AvoidEagerApis;
+import com.palantir.gradle.guide.helpers.RefactoringValidator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AvoidEagerApisTest {
+    private final CompilationTestHelper compilationTestHelper =
+            CompilationTestHelper.newInstance(AvoidEagerApis.class, getClass());
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_tasks_create() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import groovy.lang.Closure;
+                import java.util.Map;
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskContainer;
+
+                class Test {
+                    static void test(TaskContainer tasks) {
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create(Map.of("name", "lol", "type", Task.class));
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create(Map.of("name", "lol", "type", Task.class), Closure.IDENTITY);
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create("lol", Closure.IDENTITY);
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create("lol");
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create("lol", Task.class);
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create("lol", Task.class, new Object());
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create("lol", Task.class, task -> {});
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_configurations_create() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import groovy.lang.Closure;
+                import org.gradle.api.artifacts.ConfigurationContainer;
+
+                class Test {
+                    static void test(ConfigurationContainer configurations) {
+                        // BUG: Diagnostic contains: Use `.register`
+                        configurations.create("lol");
+                        // BUG: Diagnostic contains: Use `.register`
+                        configurations.create("lol", Closure.IDENTITY);
+                        // BUG: Diagnostic contains: Use `.register`
+                        configurations.create("lol", conf -> {});
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_sourcesets_create() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import groovy.lang.Closure;
+                import org.gradle.api.tasks.SourceSetContainer;
+
+                class Test {
+                    static void test(SourceSetContainer sourceSets) {
+                        // BUG: Diagnostic contains: Use `.register`
+                        sourceSets.create("lol");
+                        // BUG: Diagnostic contains: Use `.register`
+                        sourceSets.create("lol", Closure.IDENTITY);
+                        // BUG: Diagnostic contains: Use `.register`
+                        sourceSets.create("lol", conf -> {});
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_eager_task_container_apis() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskContainer;
+
+                class Test {
+                    static void test(TaskContainer tasks) {
+                        // BUG: Diagnostic contains: Use `.register`
+                        tasks.create("foo");
+                        // BUG: Diagnostic contains: Use `.named(...)` instead of `.getByName(...)`
+                        tasks.getByName("foo");
+                        // BUG: Diagnostic contains: Use `.named(...)` instead of `.findByName(...)`
+                        tasks.findByName("foo");
+                        // BUG: Diagnostic contains: Use `.named(...)` instead of `.getByPath(...)`
+                        tasks.getByPath(":foo");
+                        // BUG: Diagnostic contains: Use `.named(...)` instead of `.findByPath(...)`
+                        tasks.findByPath(":foo");
+                        // BUG: Diagnostic contains: Avoid `.replace()` - forces eager resolution and behavior may change
+                        tasks.replace("foo", Task.class);
+                        // BUG: Diagnostic contains: Use `.configureEach(...)` instead of `.whenTaskAdded(...)`
+                        tasks.whenTaskAdded(task -> {});
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_eager_task_collection_apis() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import org.gradle.api.Task;
+                import org.gradle.api.tasks.TaskCollection;
+
+                class Test {
+                    static void test(TaskCollection<Task> tasks) {
+                        // BUG: Diagnostic contains: Use `.configureEach(...)` with conditional logic instead of `.matching(...)`
+                        tasks.matching(task -> true);
+                        // BUG: Diagnostic contains: Use `.named(...)` instead of `.getAt(...)`
+                        tasks.getAt("foo");
+                        // BUG: Diagnostic contains: Use `.configureEach(...)` instead of `.all(...)`
+                        tasks.all(task -> {});
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_eager_domain_object_collection_apis() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import org.gradle.api.DomainObjectCollection;
+
+                class Test {
+                    static void test(DomainObjectCollection<Object> objects) {
+                        // BUG: Diagnostic contains: Use `.configureEach(...)` instead of `.whenObjectAdded(...)`
+                        objects.whenObjectAdded(obj -> {});
+                        // BUG: Diagnostic contains: Use `.configureEach(...)` instead of `.all(...)`
+                        objects.all(obj -> {});
+                        // BUG: Diagnostic contains: Use `.configureEach(...)` with conditional logic instead of `.matching(...)`
+                        objects.matching(obj -> true);
+                        // BUG: Diagnostic contains: Use `.named(...).configureEach(...)` instead of `.withType(...)`
+                        objects.withType(String.class);
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @SuppressWarnings("for-rollout:MisformattedTestData")
+    @Test
+    void matches_eager_named_domain_object_set_apis() {
+        compilationTestHelper.addSourceLines(
+                "Test.java",
+                // language=java
+                """
+                import org.gradle.api.NamedDomainObjectSet;
+                import groovy.lang.Closure;
+
+                class Test {
+                    static void test(NamedDomainObjectSet<Object> objects) {
+                        // BUG: Diagnostic contains: Use `.matching(...)` and `.configureEach(...)` instead of `.findAll()
+                        objects.findAll(Closure.IDENTITY);
+                        // BUG: Diagnostic contains: Use `.named()` to avoid eager configuration. Note that it fails if the task does not exist
+                        objects.findByName("foo");
+                    }
+                }
+                """);
+
+        compilationTestHelper.doTest();
+    }
+
+    @Nested
+    class BestEffortMode {
+        @Nested
+        class Tasks {
+            @Test
+            void when_return_value_is_unused_just_use_register_immediately() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.Task;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    static void test(TaskContainer tasks) {
+                                        tasks.create("lol");
+                                        tasks.create("lol", Task.class);
+                                        tasks.create("lol", Task.class, new Object());
+                                        tasks.create("lol", Task.class, task -> {});
+                                    }
+                                }
+                                """)
+                        .addOutputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.Task;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    static void test(TaskContainer tasks) {
+                                        tasks.register("lol").get();
+                                        tasks.register("lol", Task.class).get();
+                                        tasks.register("lol", Task.class, new Object()).get();
+                                        tasks.register("lol", Task.class, task -> {}).get();
+                                    }
+                                }
+                                """)
+                        .doTest();
+            }
+
+            @Test
+            void when_return_value_is_used_adds_get_call() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.Task;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    static Task test(TaskContainer tasks) {
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        Task task = tasks.create("lol");
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        System.out.println(tasks.create("lol", Task.class, t -> {}));
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        return tasks.create("lol", Task.class);
+                                    }
+                                }
+                                """)
+                        .addOutputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.Task;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    static Task test(TaskContainer tasks) {
+                                        Task task = tasks.register("lol").get();
+                                        System.out.println(tasks.register("lol", Task.class, t -> {}).get());
+                                        return tasks.register("lol", Task.class).get();
+                                    }
+                                }
+                                """)
+                        .doTest();
+            }
+
+            @Test
+            void doesnt_touch_calls_with_no_directly_equivalent_register() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import groovy.lang.Closure;
+                                import java.util.Map;
+                                import org.gradle.api.Task;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    static void test(TaskContainer tasks) {
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        tasks.create("lol", Closure.IDENTITY);
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        tasks.create(Map.of("name", "lol", "type", Task.class));
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        tasks.create(Map.of("name", "lol", "type", Task.class), Closure.IDENTITY);
+                                    }
+                                }
+                                """)
+                        .expectUnchanged()
+                        .doTest();
+            }
+
+            @Test
+            void getByName_refactored_correctly() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.DefaultTask;
+                                import org.gradle.api.Project;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    class CustomTask extends DefaultTask {}
+                                    static void test(Project project) {
+                                        CustomTask customTask = (CustomTask) project.getTasks().getByName("lol");
+
+                                        TaskContainer tasks = project.getTasks();
+                                        CustomTask customTask2 = (CustomTask) tasks.getByName("lol");
+
+                                        CustomTask wontRemoveCast = (CustomTask) project.getTasks().getByName("lol").getDependsOn().stream().findFirst().get();
+                                    }
+                                }
+                                """)
+                        .addOutputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.DefaultTask;
+                                import org.gradle.api.Project;
+                                import org.gradle.api.tasks.TaskContainer;
+
+                                class Test {
+                                    class CustomTask extends DefaultTask {}
+                                    static void test(Project project) {
+                                        CustomTask customTask = project.getTasks().named("lol", CustomTask.class).get();
+
+                                        TaskContainer tasks = project.getTasks();
+                                        CustomTask customTask2 = tasks.named("lol", CustomTask.class).get();
+
+                                        CustomTask wontRemoveCast = (CustomTask) project.getTasks().named("lol").get().getDependsOn().stream().findFirst().get();
+                                    }
+                                }
+                                """)
+                        .doTest();
+            }
+        }
+
+        @Nested
+        class Configurations {
+            @Test
+            void unused_return_value() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.artifacts.ConfigurationContainer;
+
+                                class Test {
+                                    static void test(ConfigurationContainer configurations) {
+                                        configurations.create("lol");
+                                        configurations.create("lol", conf -> {});
+                                    }
+                                }
+                                """)
+                        .addOutputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.artifacts.ConfigurationContainer;
+
+                                class Test {
+                                    static void test(ConfigurationContainer configurations) {
+                                        configurations.register("lol").get();
+                                        configurations.register("lol", conf -> {}).get();
+                                    }
+                                }
+                                """)
+                        .doTest();
+            }
+
+            @Test
+            void used_return_value() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.artifacts.Configuration;
+                                import org.gradle.api.artifacts.ConfigurationContainer;
+
+                                class Test {
+                                    static Configuration test(ConfigurationContainer configurations) {
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        Configuration configuration = configurations.create("lol");
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        System.out.println(configurations.create("lol", conf -> {}));
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        return configurations.create("lol", conf -> {});
+                                    }
+                                }
+                                """)
+                        .addOutputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import org.gradle.api.artifacts.Configuration;
+                                import org.gradle.api.artifacts.ConfigurationContainer;
+
+                                class Test {
+                                    static Configuration test(ConfigurationContainer configurations) {
+                                        Configuration configuration = configurations.register("lol").get();
+                                        System.out.println(configurations.register("lol", conf -> {}).get());
+                                        return configurations.register("lol", conf -> {}).get();
+                                    }
+                                }
+                                """)
+                        .doTest();
+            }
+
+            @Test
+            void methods_with_no_directly_equivalent_register() {
+                bestEffortRefactoringValidator()
+                        .addInputLines(
+                                "Test.java",
+                                // language=java
+                                """
+                                import groovy.lang.Closure;
+                                import org.gradle.api.artifacts.ConfigurationContainer;
+
+                                class Test {
+                                    static void test(ConfigurationContainer configurations) {
+                                        // BUG: Diagnostic contains: Use `.register`
+                                        configurations.create("lol", Closure.IDENTITY);
+                                    }
+                                }
+                                """)
+                        .expectUnchanged()
+                        .doTest();
+            }
+        }
+    }
+
+    private RefactoringValidator bestEffortRefactoringValidator() {
+        return refactoringValidator("-XepOpt:GradleGuide:BestEffortMode");
+    }
+
+    private RefactoringValidator refactoringValidator(String... args) {
+        return RefactoringValidator.of(AvoidEagerApis.class, getClass(), args);
+    }
+}

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/laziness/ProviderImprovementsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/laziness/ProviderImprovementsTest.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.palantir.gradle.guide.besteffort;
+package com.palantir.gradle.guide.laziness;
 
-import com.palantir.gradle.guide.errorprone.besteffort.ProviderImprovements;
+import com.palantir.gradle.guide.errorprone.laziness.ProviderImprovements;
 import com.palantir.gradle.guide.helpers.RefactoringValidator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

This PR adds

- An error-prone to ban common ways eagerness "sprouts" from the codebase, to prevent more eagerness from appearing in all Palantir gradle code
- Surrounding infrastructure for matching + fixing (similar to IllegalMethodCalledDuringTaskExecution)
- Two example autofixes to demonstrate said infrastructure. The autofixes are gated behind `BestEffortMode`
- 500 lines of tests

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Create `AvoidEagerApis` and surrounding infrastructure 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

