### PR TITLE
Switch from deprecated `AST_MATCH` to `TEXT_MATCH` mode

### DIFF
--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/besteffort/ProviderImprovementsTest.java
@@ -128,6 +128,7 @@ class ProviderImprovementsTest {
 
                 class Test {
                     void test(Project project, Provider<Integer> first, Provider<String> second) {
+                        // BUG: Diagnostic contains: Provider.get
                         project.provider(() -> first.get() + second.get());
                     }
                 }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ConfigurationAvoidanceRegistrationTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ConfigurationAvoidanceRegistrationTest.java
@@ -163,11 +163,8 @@ class ConfigurationAvoidanceRegistrationTest {
 
                                 class Test {
                                     static Task test(TaskContainer tasks) {
-                                        // BUG: Diagnostic contains: use `.register`
                                         Task task = tasks.create("lol");
-                                        // BUG: Diagnostic contains: use `.register`
                                         System.out.println(tasks.create("lol", Task.class, t -> {}));
-                                        // BUG: Diagnostic contains: use `.register`
                                         return tasks.create("lol", Task.class);
                                     }
                                 }
@@ -304,11 +301,8 @@ class ConfigurationAvoidanceRegistrationTest {
 
                                 class Test {
                                     static Configuration test(ConfigurationContainer configurations) {
-                                        // BUG: Diagnostic contains: use `.register`
                                         Configuration configuration = configurations.create("lol");
-                                        // BUG: Diagnostic contains: use `.register`
                                         System.out.println(configurations.create("lol", conf -> {}));
-                                        // BUG: Diagnostic contains: use `.register`
                                         return configurations.create("lol", conf -> {});
                                     }
                                 }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
@@ -203,6 +203,7 @@ class ExtensionsUseCreateTest {
                 class Test {
                     void foo(Project project) {
                         FooExtension ext = new FooExtension("a", "b");
+
                         project.getExtensions().add("foo", ext);
                     }
 
@@ -212,6 +213,7 @@ class ExtensionsUseCreateTest {
                 import org.gradle.api.Project;
                 class Test {
                     void foo(Project project) {
+
                         project.getExtensions().create("foo", FooExtension.class, "a", "b");
                     }
 
@@ -256,6 +258,7 @@ class ExtensionsUseCreateTest {
                 import org.gradle.api.Project;
                 class Test {
                     void foo(Project project) {
+
                         project.getExtensions().create("foo", FooExtension.class, "a", "b");
                     }
                     class FooExtension { FooExtension(String a, String b) {} }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
@@ -345,7 +345,7 @@ class ExtensionsUseCreateTest {
             refactoringTestHelper
                     .addInputLines("Test.java", input)
                     .addOutputLines("Test.java", expected)
-                    .doTest();
+                    .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
         }
 
         private void refactoringNoop(@Language("Java") String code) {
@@ -355,7 +355,7 @@ class ExtensionsUseCreateTest {
             refactoringTestHelper
                     .addInputLines("Test.java", code)
                     .expectUnchanged()
-                    .doTest();
+                    .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
         }
     }
 }

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ArchiveOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ArchiveOperationsFixesTest.java
@@ -43,8 +43,10 @@ public class ArchiveOperationsFixesTest extends IllegalMethodCalledDuringTaskExe
             import org.gradle.api.file.FileTree;
             import org.gradle.api.tasks.TaskAction;
             abstract class AlreadyAbstractTask extends DefaultTask {
+
                 @Inject
                 protected abstract ArchiveOperations getArchiveOperations();
+
                 @TaskAction
                 final void action() {
                     FileTree fileTree = getArchiveOperations().tarTree("happy-squirrel.tar");
@@ -201,8 +203,10 @@ public class ArchiveOperationsFixesTest extends IllegalMethodCalledDuringTaskExe
             import org.gradle.api.file.FileTree;
             import org.gradle.api.tasks.TaskAction;
             abstract class ConcreteTask extends DefaultTask {
+
                 @Inject
                 protected abstract ArchiveOperations getArchiveOperations();
+
                 @TaskAction
                 final void action() {
                     FileTree fileTree = getArchiveOperations().tarTree("happy-squirrel.tar");

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ExecOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ExecOperationsFixesTest.java
@@ -47,8 +47,10 @@ public class ExecOperationsFixesTest extends IllegalMethodCalledDuringTaskExecut
             import org.gradle.api.tasks.TaskAction;
             import org.gradle.process.ExecOperations;
             abstract class ConcreteTask extends DefaultTask {
+
                 @Inject
                 protected abstract ExecOperations getExecOperations();
+
                 @TaskAction
                 final void action() {
                     getExecOperations().exec(execSpec -> {

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/FileSystemOperationsFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/FileSystemOperationsFixesTest.java
@@ -55,8 +55,10 @@ public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTask
             import org.gradle.api.file.FileSystemOperations;
             import org.gradle.api.tasks.TaskAction;
             abstract class AlreadyAbstractTask extends DefaultTask {
+
                 @Inject
                 protected abstract FileSystemOperations getFileSystemOperations();
+
                 @TaskAction
                 final void action() {
                     getFileSystemOperations().copy(copySpec -> {
@@ -257,8 +259,10 @@ public class FileSystemOperationsFixesTest extends IllegalMethodCalledDuringTask
             import org.gradle.api.file.FileSystemOperations;
             import org.gradle.api.tasks.TaskAction;
             abstract class ConcreteTask extends DefaultTask {
+
                 @Inject
                 protected abstract FileSystemOperations getFileSystemOperations();
+
                 @TaskAction
                 final void action() {
                     getFileSystemOperations().delete(deleteSpec -> {

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/GetProjectGetLoggerTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/GetProjectGetLoggerTest.java
@@ -56,6 +56,7 @@ public class GetProjectGetLoggerTest extends IllegalMethodCalledDuringTaskExecut
                 abstract class CustomTask extends DefaultTask {
                     @TaskAction
                     final void action() {
+                        // BUG: Diagnostic contains: Don't call `getProject()` in task actions
                         getProject();  // not fixable
                         Logger logger = getProject().getLogger();  // fixable to getLogger()
                     }
@@ -69,8 +70,8 @@ public class GetProjectGetLoggerTest extends IllegalMethodCalledDuringTaskExecut
                 @TaskAction
                 final void action() {
                     // BUG: Diagnostic contains: Don't call `getProject()` in task actions
-                    getProject();
-                    Logger logger = getLogger();
+                    getProject(); // not fixable
+                    Logger logger = getLogger(); // fixable to getLogger()
                 }
             }
             """);
@@ -105,7 +106,7 @@ public class GetProjectGetLoggerTest extends IllegalMethodCalledDuringTaskExecut
                     }
 
                     void helper() {
-                        Logger logger = getLogger();
+                        Logger logger = getLogger();  // fixable to getLogger()
                     }
                 }
             """);
@@ -134,7 +135,7 @@ public class GetProjectGetLoggerTest extends IllegalMethodCalledDuringTaskExecut
                 abstract class CustomTaskAction implements Action<Task> {
                     @Override
                     public void execute(Task task) {
-                        Logger logger = task.getLogger();
+                        Logger logger = task.getLogger(); // fixable to getLogger()
                     }
                 }
             """);

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ObjectFactoryFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ObjectFactoryFixesTest.java
@@ -56,8 +56,10 @@ public class ObjectFactoryFixesTest extends IllegalMethodCalledDuringTaskExecuti
                 import org.gradle.api.tasks.TaskAction;
 
                 abstract class CustomTask extends DefaultTask {
+
                     @Inject
                     protected abstract ObjectFactory getObjectFactory();
+
                     @TaskAction
                     final void action() {
                         getObjectFactory().setProperty(String.class);

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ProjectLayoutFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ProjectLayoutFixesTest.java
@@ -46,6 +46,7 @@ public class ProjectLayoutFixesTest extends IllegalMethodCalledDuringTaskExecuti
                 import org.gradle.api.tasks.TaskAction;
 
                 abstract class AlreadyAbstractTask extends DefaultTask {
+
                     @Inject
                     protected abstract ProjectLayout getProjectLayout();
 
@@ -137,6 +138,7 @@ public class ProjectLayoutFixesTest extends IllegalMethodCalledDuringTaskExecuti
                 import org.gradle.api.tasks.TaskAction;
 
                 abstract class ConcreteTask extends DefaultTask {
+
                     @Inject
                     protected abstract ProjectLayout getProjectLayout();
 

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ProviderFactoryFixesTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/taskexecution/ProviderFactoryFixesTest.java
@@ -41,8 +41,10 @@ public class ProviderFactoryFixesTest extends IllegalMethodCalledDuringTaskExecu
                 import org.gradle.api.tasks.TaskAction;
 
                 abstract class CustomTask extends DefaultTask {
+
                     @Inject
                     protected abstract ProviderFactory getProviderFactory();
+
                     @TaskAction
                     final void action() {
                         getProviderFactory().provider(() -> "happy squirrel");

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/helpers/RefactoringValidator.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/helpers/RefactoringValidator.java
@@ -87,7 +87,7 @@ public final class RefactoringValidator {
         }
 
         public void doTest() {
-            delegate.doTest();
+            delegate.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
             helper.compilationHelper
                     .addSourceLines(helper.outputPath, helper.outputLines)
                     .matchAllDiagnostics()

--- a/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
+++ b/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
@@ -23,7 +23,24 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
         // language=Gradle
         buildFile << '''
             apply plugin: 'com.palantir.gradle-guide'
+            apply plugin: 'com.palantir.baseline-java-versions'
             
+            javaVersions {
+                javaCompiler = 25
+                libraryTarget = 17
+            }
+
+            buildscript {
+                repositories {
+                    mavenCentral()
+                    gradlePluginPortal()
+                    mavenLocal()
+                }
+                dependencies {
+                    classpath "com.palantir.baseline:gradle-baseline-java:7.4.0"
+                } 
+            }
+
             allprojects {
                 repositories {
                     mavenCentral()
@@ -31,6 +48,7 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
                 }
                 
                 apply plugin: 'java'
+
              
                 pluginManager.withPlugin('com.palantir.suppressible-error-prone') {
                     suppressibleErrorProne {
@@ -45,7 +63,7 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
                             errorprone "com.palantir.gradle.guide:gradle-guide-error-prone:${System.getProperty('gradleGuideErrorProneVersion')}"
                         }
                         
-                        errorprone 'com.google.errorprone:error_prone_core:2.36.0'
+                        errorprone 'com.google.errorprone:error_prone_core:2.49.0'
                     }
                 }
             }

--- a/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
+++ b/gradle-guide/src/test/groovy/com/palantir/gradle/guide/GradleGuidePluginIntegrationSpec.groovy
@@ -23,24 +23,7 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
         // language=Gradle
         buildFile << '''
             apply plugin: 'com.palantir.gradle-guide'
-            apply plugin: 'com.palantir.baseline-java-versions'
             
-            javaVersions {
-                javaCompiler = 25
-                libraryTarget = 17
-            }
-
-            buildscript {
-                repositories {
-                    mavenCentral()
-                    gradlePluginPortal()
-                    mavenLocal()
-                }
-                dependencies {
-                    classpath "com.palantir.baseline:gradle-baseline-java:7.4.0"
-                } 
-            }
-
             allprojects {
                 repositories {
                     mavenCentral()
@@ -48,7 +31,6 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
                 }
                 
                 apply plugin: 'java'
-
              
                 pluginManager.withPlugin('com.palantir.suppressible-error-prone') {
                     suppressibleErrorProne {
@@ -63,7 +45,7 @@ class GradleGuidePluginIntegrationSpec extends IntegrationSpec {
                             errorprone "com.palantir.gradle.guide:gradle-guide-error-prone:${System.getProperty('gradleGuideErrorProneVersion')}"
                         }
                         
-                        errorprone 'com.google.errorprone:error_prone_core:2.49.0'
+                        errorprone 'com.google.errorprone:error_prone_core:2.36.0'
                     }
                 }
             }


### PR DESCRIPTION
## Before this PR

error-prone 2.49.0 switches `BugCheckerRefactoringTestHelper` to [TEXT_MATCH mode as default](https://github.com/google/error-prone/commit/ccfc176eb7#diff-d1a322c5302810becfb0cbc80fb0d611800a40b3682ad149b8bb2d08623d0c33R288) and [deprecates AST_MATCH mode](https://github.com/google/error-prone/commit/190e452caa94e7a351e4e6f585fc1d7a640c6f1a). 

This tightens the criterion for an (actual, expected) pair to be matched. Whitespaces and comments are taken into consideration now.

This is a purely test behavior change, no consumers should be expected.

## After this PR

Switch to TEXT_MATCH mode in preparation for error-prone 2.49.0

