### PR TITLE
Re-enable Error Prone checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,11 +61,6 @@ allprojects {
             disable("PreferSafeLoggingPreconditions")
         }
     }
-
-    // TEMPHACK: reenable when baseline-error-prone etc are errorprone 2.49.0 compatible
-    tasks.withType(JavaCompile).configureEach {
-        options.errorprone.enabled = false
-    }
 }
 
 javaVersions {

--- a/changelog/@unreleased/pr-463.v2.yml
+++ b/changelog/@unreleased/pr-463.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Re-enabled this repository's Error Prone checks.
+  links:
+  - https://github.com/palantir/gradle-guide/pull/463

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/errorprone/ExtensionsUseCreateTest.java
@@ -341,6 +341,7 @@ class ExtensionsUseCreateTest {
                 """);
         }
 
+        @SuppressWarnings("deprecation")
         private void refactoringTest(@Language("Java") String input, @Language("Java") String expected) {
             BugCheckerRefactoringTestHelper refactoringTestHelper =
                     BugCheckerRefactoringTestHelper.newInstance(ExtensionsUseCreate.class, getClass());
@@ -351,6 +352,7 @@ class ExtensionsUseCreateTest {
                     .doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
         }
 
+        @SuppressWarnings("deprecation")
         private void refactoringNoop(@Language("Java") String code) {
             BugCheckerRefactoringTestHelper refactoringTestHelper =
                     BugCheckerRefactoringTestHelper.newInstance(ExtensionsUseCreate.class, getClass());

--- a/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/helpers/RefactoringValidator.java
+++ b/gradle-guide-error-prone/src/test/java/com/palantir/gradle/guide/helpers/RefactoringValidator.java
@@ -77,7 +77,6 @@ public final class RefactoringValidator {
     }
 
     public static final class TestStage {
-
         private final RefactoringValidator helper;
         private final BugCheckerRefactoringTestHelper delegate;
 
@@ -86,6 +85,7 @@ public final class RefactoringValidator {
             this.delegate = delegate;
         }
 
+        @SuppressWarnings("deprecation")
         public void doTest() {
             delegate.doTest(BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH);
             helper.compilationHelper
@@ -94,6 +94,7 @@ public final class RefactoringValidator {
                     .doTest();
         }
 
+        @SuppressWarnings("deprecation")
         public void doTest(BugCheckerRefactoringTestHelper.TestMode testMode) {
             delegate.doTest(testMode);
             helper.compilationHelper
@@ -102,6 +103,7 @@ public final class RefactoringValidator {
                     .doTest();
         }
 
+        @SuppressWarnings("deprecation")
         public void doTestExpectingFailure(BugCheckerRefactoringTestHelper.TestMode testMode) {
             delegate.doTest(testMode);
             assertThatThrownBy(() -> helper.compilationHelper

--- a/gradle-guide/src/test/java/com/palantir/gradle/guide/GradleGuidePluginIntegrationTest.java
+++ b/gradle-guide/src/test/java/com/palantir/gradle/guide/GradleGuidePluginIntegrationTest.java
@@ -57,8 +57,6 @@ class GradleGuidePluginIntegrationTest {
                     mavenLocal()
                 }
 
-                apply plugin: 'java'
-
                 pluginManager.withPlugin('com.palantir.suppressible-error-prone') {
                     suppressibleErrorProne {
                         configureEachErrorProneOptions {
@@ -76,6 +74,7 @@ class GradleGuidePluginIntegrationTest {
                 }
             }
             """);
+        rootProject.buildGradle().plugins().add("java");
     }
 
     @Test

--- a/gradle-guide/src/test/java/com/palantir/gradle/guide/GradleGuidePluginIntegrationTest.java
+++ b/gradle-guide/src/test/java/com/palantir/gradle/guide/GradleGuidePluginIntegrationTest.java
@@ -80,6 +80,7 @@ class GradleGuidePluginIntegrationTest {
     @Test
     void registers_errorprones_correctly_in_subproject_that_uses_gradle_api(
             GradleInvoker gradle, SubProject gradleApi) {
+        gradleApi.buildGradle().plugins().add("java");
         gradleApi.buildGradle().append("""
             dependencies {
                 compileOnly gradleApi()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Error Prone was still disabled in this repo after the 2.49.0 compatibility work landed.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Re-enable Error Prone checks

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->